### PR TITLE
feat(@clack/prompts): add prompt `workflow`

### DIFF
--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -13,7 +13,8 @@
     "stream": "jiti ./stream.ts",
     "spinner": "jiti ./spinner.ts",
     "spinner-ci": "npx cross-env CI=\"true\" jiti ./spinner-ci.ts",
-    "spinner-timer": "jiti ./spinner-timer.ts"
+    "spinner-timer": "jiti ./spinner-timer.ts",
+    "workflow": "jiti ./workflow.ts"
   },
   "devDependencies": {
     "jiti": "^1.17.0"

--- a/examples/basic/workflow.ts
+++ b/examples/basic/workflow.ts
@@ -1,0 +1,65 @@
+import * as p from '@clack/prompts';
+
+(async () => {
+	const results = await p
+		.workflow()
+		.step('name', () => p.text({ message: 'What is your package name?' }))
+		.step('type', () =>
+			p.select({
+				message: 'Pick a project type:',
+				initialValue: 'ts',
+				maxItems: 5,
+				options: [
+					{ value: 'ts', label: 'TypeScript' },
+					{ value: 'js', label: 'JavaScript' },
+					{ value: 'rust', label: 'Rust' },
+					{ value: 'go', label: 'Go' },
+					{ value: 'python', label: 'Python' },
+					{ value: 'coffee', label: 'CoffeeScript', hint: 'oh no' },
+				],
+			})
+		)
+		.step('install', () =>
+			p.confirm({
+				message: 'Install dependencies?',
+				initialValue: false,
+			})
+		)
+		.forkStep(
+			'fork',
+			({ results }) => results.install,
+			({ results }) => {
+				return p.workflow().step('package', () =>
+					p.select({
+						message: 'Pick a package manager:',
+						initialValue: 'pnpm',
+						options: [
+							{
+								label: 'npm',
+								value: 'npm',
+							},
+							{
+								label: 'yarn',
+								value: 'yarn',
+							},
+							{
+								label: 'pnpm',
+								value: 'pnpm',
+							},
+						],
+					})
+				);
+			}
+		)
+		.run();
+
+	await p
+		.workflow()
+		.step('cancel', () => p.text({ message: 'Try cancel prompt (Ctrl + C):' }))
+		.step('afterCancel', () => p.text({ message: 'This will not appear!' }))
+		.onCancel(({ results }) => {
+			p.cancel('Workflow canceled');
+			process.exit(0);
+		})
+		.run();
+})();

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -159,6 +159,72 @@ const group = await p.group(
 console.log(group.name, group.age, group.color);
 ```
 
+### Workflow
+
+Works just like `group` but infer types way better and treats your group like a workflow, allowing you to create conditional steps (forks) along the process.
+
+```js
+import * as p from '@clack/prompts';
+
+const results = await p
+  .workflow()
+  .step('name', () => p.text({ message: 'What is your package name?' }))
+  .step('type', () =>
+    p.select({
+      message: `Pick a project type:`,
+      initialValue: 'ts',
+      maxItems: 5,
+      options: [
+        { value: 'ts', label: 'TypeScript' },
+        { value: 'js', label: 'JavaScript' },
+        { value: 'rust', label: 'Rust' },
+        { value: 'go', label: 'Go' },
+        { value: 'python', label: 'Python' },
+        { value: 'coffee', label: 'CoffeeScript', hint: 'oh no' },
+      ],
+    })
+  )
+  .step('install', () =>
+    p.confirm({
+      message: 'Install dependencies?',
+      initialValue: false,
+    })
+  )
+  .step('fork', ({ results }) => {
+    if (results.install === true) {
+      return p
+        .workflow()
+        .step('package', () =>
+          p.select({
+            message: 'Pick a package manager:',
+            initialValue: 'pnpm',
+            options: [
+              {
+                label: 'npm',
+                value: 'npm',
+              },
+              {
+                label: 'yarn',
+                value: 'yarn',
+              },
+              {
+                label: 'pnpm',
+                value: 'pnpm',
+              },
+            ],
+          })
+        )
+        .run();
+    }
+  })
+  .onCancel(() => {
+    p.cancel('Workflow canceled');
+    process.exit(0);
+  })
+  .run();
+console.log(results);
+```
+
 ### Tasks
 
 Execute multiple tasks in spinners.


### PR DESCRIPTION
Since Typescript has shown a limitation on infer `group` results, discussed in @chrissantamaria's [comment on PR#102]( https://github.com/natemoo-re/clack/pull/102#issuecomment-1465068829), and Issue #131. This functionality presents an alternative for users who favor the builder pattern when dealing with multiple prompts in sequence, serving as either a workaround or an additional choice, while avoid a breaking change.

This PR includes:
- [x] Code
- [x] Docs
- [x] Changeset
- [x] Example

I am open to discussions on comment's section!

Closes #131
Closes #109 