### PR TITLE
feat(@clack/core,@clack/prompts): multiline support

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,5 +9,5 @@ export { default as Prompt } from './prompts/prompt.js';
 export { default as SelectPrompt } from './prompts/select.js';
 export { default as SelectKeyPrompt } from './prompts/select-key.js';
 export { default as TextPrompt } from './prompts/text.js';
-export { block, isCancel } from './utils/index.js';
+export { block, isCancel, strLength } from './utils/index.js';
 export { updateSettings } from './utils/settings.js';


### PR DESCRIPTION
# Multiline Support
Support multiline texts either with \n, or long ones that exceed terminal width, without breaking the layout

## List of supported prompts:
- [x] text
- [x] password
- [ ] confirm
    - Is just `yes`/`no`
- [x] select
- [ ] selectKey
    - It was made to handle short options
- [x] multiselect
- [ ] groupMultiselect
    - It was made to handle short options
- [x] note
- [x] intro
- [x] cancel
- [x] outro
- [x] log
- [x] spinner

Continuation of #141 

Closes #101
Closes #132 
Relates #135 #111 #35