### PR TITLE
feat(@clack/prompts): add `disabled` option to `select` and `multiselect` prompts

### DIFF
--- a/.changeset/little-horses-sort.md
+++ b/.changeset/little-horses-sort.md
@@ -1,0 +1,5 @@
+---
+'@clack/prompts': patch
+---
+
+feat: add `disabled` option to `select` and `multiselect` prompts

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -267,7 +267,10 @@ export interface SelectOptions<Value> {
 }
 
 export const select = <Value>(opts: SelectOptions<Value>) => {
-	const opt = (option: Option<Value>, state: 'inactive' | 'active' | 'selected' | 'cancelled') => {
+	const opt = (
+		option: Option<Value>,
+		state: 'inactive' | 'active' | 'selected' | 'cancelled'
+	) => {
 		const label = option.label ?? String(option.value);
 		switch (state) {
 			case 'selected':
@@ -414,7 +417,7 @@ export const multiselect = <Value>(opts: MultiSelectOptions<Value>) => {
 		required: opts.required ?? true,
 		cursorAt: opts.cursorAt,
 		validate(selected: Value[]) {
-			if (this.required && selected.length === 0)
+			if (this.required && selected.length === 0) {
 				return `Please select at least one option.\n${color.reset(
 					color.dim(
 						`Press ${color.gray(color.bgWhite(color.inverse(' space ')))} to select, ${color.gray(
@@ -422,6 +425,20 @@ export const multiselect = <Value>(opts: MultiSelectOptions<Value>) => {
 						)} to submit`
 					)
 				)}`;
+			}
+			const disabledOptions = opts.options
+				.map((option) => {
+					if (selected.includes(option.value) && option.disabled) {
+						return option.label ?? option.value;
+					}
+					return undefined;
+				})
+				.filter(Boolean);
+			if (disabledOptions.length) {
+				return `${disabledOptions.join(', ')} ${
+					disabledOptions.length > 1 ? 'options are' : 'option is'
+				} disabled.`;
+			}
 		},
 		render() {
 			const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -228,6 +228,12 @@ export type Option<Value> = Value extends Primitive
 			 * By default, no `hint` is displayed.
 			 */
 			hint?: string;
+			/**
+			 * If true, this option will be disabled.
+			 *
+			 * By default, no option is disabled.
+			 */
+			disabled?: boolean;
 		}
 	: {
 			/**
@@ -245,6 +251,12 @@ export type Option<Value> = Value extends Primitive
 			 * By default, no `hint` is displayed.
 			 */
 			hint?: string;
+			/**
+			 * If true, this option will be disabled.
+			 *
+			 * By default, no option is disabled.
+			 */
+			disabled?: boolean;
 		};
 
 export interface SelectOptions<Value> {
@@ -274,6 +286,11 @@ export const select = <Value>(opts: SelectOptions<Value>) => {
 	return new SelectPrompt({
 		options: opts.options,
 		initialValue: opts.initialValue,
+		validate(value) {
+			if (this.options.find((o) => o.value === value)?.disabled) {
+				return 'Selected option is disabled.';
+			}
+		},
 		render() {
 			const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;
 
@@ -285,6 +302,15 @@ export const select = <Value>(opts: SelectOptions<Value>) => {
 						this.options[this.cursor],
 						'cancelled'
 					)}\n${color.gray(S_BAR)}`;
+				case 'error':
+					return `${title}${color.yellow(S_BAR)}  ${limitOptions({
+						cursor: this.cursor,
+						options: this.options,
+						maxItems: opts.maxItems,
+						style: (item, active) => opt(item, active ? 'active' : 'inactive'),
+					}).join(
+						`\n${color.yellow(S_BAR)}  `
+					)}\n${color.yellow(S_BAR_END)}  ${color.yellow(this.error)}\n`;
 				default: {
 					return `${title}${color.cyan(S_BAR)}  ${limitOptions({
 						cursor: this.cursor,

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -267,10 +267,7 @@ export interface SelectOptions<Value> {
 }
 
 export const select = <Value>(opts: SelectOptions<Value>) => {
-	const opt = (
-		option: Option<Value>,
-		state: 'inactive' | 'active' | 'selected' | 'cancelled'
-	) => {
+	const opt = (option: Option<Value>, state: 'inactive' | 'active' | 'selected' | 'cancelled') => {
 		const label = option.label ?? String(option.value);
 		switch (state) {
 			case 'selected':


### PR DESCRIPTION
This PR introduces a new `disabled` option for both the `select` and `multiselect` prompts. When this option is enabled, it prevents users from selecting the specified prompt's option. It's worth noting that while the `multiselect` prompt doesn't allow blocking the `mark` action, the `disabled` option will effectively block it upon submission.

### Changes Made:

- Added a `disabled` option to the `select` and `multiselect` prompts to allow blocking user selection.
- Implemented functionality to prevent selection of prompts when the `disabled` option is enabled.
- Ensured that the `mark` action is blocked in the `multiselect` prompt when it is disabled upon submission.


### Demo:

https://github.com/natemoo-re/clack/assets/100330057/1293df96-6700-4e80-bb2b-5f7272b37f66

Closes #122 
