### PR TITLE
chore(@clack/prompts): update readme

### DIFF
--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -34,7 +34,9 @@ The `isCancel` function is a guard that detects when a user cancels a question w
 ```js
 import { isCancel, cancel, text } from '@clack/prompts';
 
-const value = await text(/* TODO */);
+const value = await text({
+	message: 'What is the meaning of life?',
+});
 
 if (isCancel(value)) {
   cancel('Operation cancelled.');


### PR DESCRIPTION
Currently if we just copy the example code of [cancellation](https://github.com/natemoo-re/clack/tree/main/packages/prompts#cancellation), it will throw an error:

```
TypeError: Cannot read properties of undefined (reading 'validate')
```

It might be useful to fill in the required parameters here to ensure that newbies don't get an error when copying this code~