### PR TITLE
feat(@clack/core,@clack/prompts): add `Error` support for `prompt.validate`

### DIFF
--- a/.changeset/moody-hairs-learn.md
+++ b/.changeset/moody-hairs-learn.md
@@ -3,4 +3,4 @@
 '@clack/core': patch
 ---
 
-Add Error support for validate function
+Adds `Error` support to the `validate` function

--- a/.changeset/moody-hairs-learn.md
+++ b/.changeset/moody-hairs-learn.md
@@ -1,0 +1,6 @@
+---
+'@clack/prompts': patch
+'@clack/core': patch
+---
+
+Add Error support for validate function

--- a/packages/core/src/prompts/prompt.ts
+++ b/packages/core/src/prompts/prompt.ts
@@ -13,7 +13,7 @@ export interface PromptOptions<Self extends Prompt> {
 	render(this: Omit<Self, 'prompt'>): string | undefined;
 	placeholder?: string;
 	initialValue?: any;
-	validate?: ((value: any) => string | undefined) | undefined;
+	validate?: ((value: any) => string | Error | undefined) | undefined;
 	input?: Readable;
 	output?: Writable;
 	debug?: boolean;
@@ -183,7 +183,7 @@ export default class Prompt {
 			if (this.opts.validate) {
 				const problem = this.opts.validate(this.value);
 				if (problem) {
-					this.error = problem;
+					this.error = problem instanceof Error ? problem.message : problem;
 					this.state = 'error';
 					this.rl.write(this.value);
 				}

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -100,7 +100,7 @@ export interface TextOptions {
 	placeholder?: string;
 	defaultValue?: string;
 	initialValue?: string;
-	validate?: (value: string) => string | undefined;
+	validate?: (value: string) => string | Error | undefined;
 }
 export const text = (opts: TextOptions) => {
 	return new TextPrompt({
@@ -136,7 +136,7 @@ export const text = (opts: TextOptions) => {
 export interface PasswordOptions {
 	message: string;
 	mask?: string;
-	validate?: (value: string) => string | undefined;
+	validate?: (value: string) => string | Error | undefined;
 }
 export const password = (opts: PasswordOptions) => {
 	return new PasswordPrompt({


### PR DESCRIPTION
Close #160 