### PR TITLE
feat: Adding a new warn state to the validate method

### DIFF
--- a/examples/basic/index.ts
+++ b/examples/basic/index.ts
@@ -16,16 +16,16 @@ async function main() {
 					message: 'Where should we create your project?',
 					placeholder: './sparkling-solid',
 					validate: (value) => {
-						if (!value) return 'Please enter a path.';
-						if (value[0] !== '.') return 'Please enter a relative path.';
+						if (!value) return { status: 'error', message: 'Please enter a path.' };
+						if (value[0] !== '.') return { status: 'warn', message: 'warn: Relative path may not work' };
 					},
 				}),
 			password: () =>
 				p.password({
 					message: 'Provide a password',
 					validate: (value) => {
-						if (!value) return 'Please enter a password.';
-						if (value.length < 5) return 'Password should have at least 5 characters.';
+						if (!value) return { status: 'error', message: 'Please enter a password.' };
+						if (value.length < 5) return { status: 'warn', message: 'warn: Password security is too low' };
 					},
 				}),
 			type: ({ results }) =>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@ export { default as GroupMultiSelectPrompt } from './prompts/group-multiselect';
 export { default as MultiSelectPrompt } from './prompts/multi-select';
 export { default as PasswordPrompt } from './prompts/password';
 export { default as Prompt, isCancel } from './prompts/prompt';
-export type { State } from './prompts/prompt';
+export type { State, ValidateType } from './prompts/prompt';
 export { default as SelectPrompt } from './prompts/select';
 export { default as SelectKeyPrompt } from './prompts/select-key';
 export { default as TextPrompt } from './prompts/text';

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -56,8 +56,13 @@ const meaning = await text({
   placeholder: 'Not sure',
   initialValue: '42',
   validate(value) {
-    if (value.length === 0) return `Value is required!`;
-  },
+    if (value.length === 0) {
+		return {
+			status:'error',
+			message:'Value is required!'
+	    };
+	}
+  }
 });
 ```
 


### PR DESCRIPTION
At present, validate method can only return a string, and can only indicate a state (error state), but sometimes you may just want to remind the user of some precautions rather than directly preventing the user to continue to execute the programme, so I modified the type of return of validate method.
```ts
export type ValidateType = ((value: any) => ({ status: 'error' | 'warn', message: string } | void));
```
The error and warn states are triggered in the same way, the difference between the two is that the terminal won't stop the user from continuing after the warn is triggered, you just need to press Enter again to pass the current option.

https://github.com/bombshell-dev/clack/assets/60871037/1a6d2f79-5284-48bf-b1db-e41730a7417b


