### PR TITLE
feat: Inactive group headers for `GroupMultiSelectPrompt`

### DIFF
--- a/.changeset/early-deers-cough.md
+++ b/.changeset/early-deers-cough.md
@@ -1,0 +1,6 @@
+---
+'@clack/prompts': minor
+'@clack/core': minor
+---
+
+feat: added `selectableGroups` option for inactive group headers for `GroupMultiSelectPrompt`

--- a/packages/core/src/prompts/group-multiselect.ts
+++ b/packages/core/src/prompts/group-multiselect.ts
@@ -46,6 +46,7 @@ export default class GroupMultiSelectPrompt<T extends { value: any }> extends Pr
 	constructor(opts: GroupMultiSelectOptions<T>) {
 		super(opts, false);
 		const { options } = opts;
+		this.#selectableGroups = opts.selectableGroups ?? true;
 		this.options = Object.entries(options).flatMap(([key, option]) => [
 			{ value: key, group: true, label: key },
 			...option.map((opt) => ({ ...opt, group: key })),
@@ -53,9 +54,8 @@ export default class GroupMultiSelectPrompt<T extends { value: any }> extends Pr
 		this.value = [...(opts.initialValues ?? [])];
 		this.cursor = Math.max(
 			this.options.findIndex(({ value }) => value === opts.cursorAt),
-			0
+			this.#selectableGroups ? 0 : 1
 		);
-		this.#selectableGroups = opts.selectableGroups ?? true;
 
 		this.on('cursor', (key) => {
 			switch (key) {

--- a/packages/core/src/prompts/group-multiselect.ts
+++ b/packages/core/src/prompts/group-multiselect.ts
@@ -6,10 +6,12 @@ interface GroupMultiSelectOptions<T extends { value: any }>
 	initialValues?: T['value'][];
 	required?: boolean;
 	cursorAt?: T['value'];
+	selectableGroups?: boolean;
 }
 export default class GroupMultiSelectPrompt<T extends { value: any }> extends Prompt {
 	options: (T & { group: string | boolean })[];
 	cursor: number = 0;
+	#selectableGroups: boolean;
 
 	getGroupItems(group: string): T[] {
 		return this.options.filter((o) => o.group === group);
@@ -17,7 +19,7 @@ export default class GroupMultiSelectPrompt<T extends { value: any }> extends Pr
 
 	isGroupSelected(group: string) {
 		const items = this.getGroupItems(group);
-		return items.every((i) => this.value.includes(i.value));
+		return this.#selectableGroups && items.every((i) => this.value.includes(i.value));
 	}
 
 	private toggleValue() {
@@ -53,16 +55,23 @@ export default class GroupMultiSelectPrompt<T extends { value: any }> extends Pr
 			this.options.findIndex(({ value }) => value === opts.cursorAt),
 			0
 		);
+		this.#selectableGroups = opts.selectableGroups ?? true;
 
 		this.on('cursor', (key) => {
 			switch (key) {
 				case 'left':
 				case 'up':
 					this.cursor = this.cursor === 0 ? this.options.length - 1 : this.cursor - 1;
+					if (!this.#selectableGroups && this.options[this.cursor].group === true) {
+						this.cursor = this.cursor === 0 ? this.options.length - 1 : this.cursor - 1;
+					}
 					break;
 				case 'down':
 				case 'right':
-					this.cursor = this.cursor === this.options.length - 1 ? 0 : this.cursor + 1;
+					this.cursor = this.cursor === this.options.length - 1 ? 0 : this.cursor + 1; 
+					if (!this.#selectableGroups && this.options[this.cursor].group === true) {
+						this.cursor = this.cursor === this.options.length - 1 ? 0 : this.cursor + 1; 
+					}
 					break;
 				case 'space':
 					this.toggleValue();

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -428,8 +428,10 @@ export interface GroupMultiSelectOptions<Value> {
 	initialValues?: Value[];
 	required?: boolean;
 	cursorAt?: Value;
+	selectableGroups?: boolean;
 }
 export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) => {
+	const selectableGroups = opts.selectableGroups ?? true;
 	const opt = (
 		option: Option<Value>,
 		state:
@@ -468,7 +470,7 @@ export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) =>
 		} else if (state === 'submitted') {
 			return `${color.dim(label)}`;
 		}
-		return `${color.dim(prefix)}${color.dim(S_CHECKBOX_INACTIVE)} ${color.dim(label)}`;
+		return `${color.dim(prefix)}${isItem || selectableGroups ? color.dim(S_CHECKBOX_INACTIVE) : ""} ${color.dim(label)}`;
 	};
 
 	return new GroupMultiSelectPrompt({
@@ -476,6 +478,7 @@ export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) =>
 		initialValues: opts.initialValues,
 		required: opts.required ?? true,
 		cursorAt: opts.cursorAt,
+		selectableGroups: opts.selectableGroups,
 		validate(selected: Value[]) {
 			if (this.required && selected.length === 0)
 				return `Please select at least one option.\n${color.reset(

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -478,7 +478,7 @@ export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) =>
 		initialValues: opts.initialValues,
 		required: opts.required ?? true,
 		cursorAt: opts.cursorAt,
-		selectableGroups: opts.selectableGroups,
+		selectableGroups: selectableGroups,
 		validate(selected: Value[]) {
 			if (this.required && selected.length === 0)
 				return `Please select at least one option.\n${color.reset(


### PR DESCRIPTION
Closes #197 

By default, group headers are selectable, allowing you to quickly select all of the options within that group. Setting the new option, `selectableGroups`, to `false` will disable them, making the group headers inactive.

the following code snippet:
```ts
import { groupMultiselect } from "@clack/prompts";

await groupMultiselect({
	message: "Which libraries would you like to setup?",
	selectableGroups: false,
	cursorAt: "Bootstrap",
	options: {
		CSS: [
			{ label: "Bootstrap", value: "Bootstrap" },
			{ label: "TailwindCSS", value: "TailwindCSS" },
			{ label: "UnoCSS", value: "UnoCSS" },
			{ label: "Bulma", value: "Bulma" },
		],
		Testing: [
			{ label: "Playwright", value: "Playwright" },
			{ label: "Vitest", value: "Vitest" },
		],
		Database: [
			{ label: "Drizzle", value: "Drizzle" },
			{ label: "Prisma", value: "Prisma" },
		],
		Auth: [
			{ label: "Lucia", value: "Lucia" },
			{ label: "Auth.js", value: "Auth.js" },
		],
	},
});
```

will produce this prompt:
![img](https://i.imgur.com/OldsJro.gif)