### PR TITLE
add missing license file

### DIFF
--- a/.changeset/plenty-days-study.md
+++ b/.changeset/plenty-days-study.md
@@ -1,0 +1,5 @@
+---
+'@clack/core': patch
+---
+
+Adds missing `LICENSE` file. Since the `package.json` file has always included `"license": "MIT"`, please consider this a licensing clarification rather than a licensing change.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,1 @@
+packages/core/LICENSE

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) Nate Moore
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Adds missing `LICENSE` file to the `@clack/core`. Since it has always been marked as MIT in `package.json`, please consider this a licensing clarification rather than a licensing change.

Closes #206