### PR TITLE
Fixes cursor position for TextPrompt

### DIFF
--- a/.changeset/seven-fireants-cover.md
+++ b/.changeset/seven-fireants-cover.md
@@ -1,0 +1,5 @@
+---
+"@clack/core": patch
+---
+
+Fixes a rendering bug with cursor positions for `TextPrompt`

--- a/packages/core/src/prompts/text.ts
+++ b/packages/core/src/prompts/text.ts
@@ -7,7 +7,17 @@ export interface TextOptions extends PromptOptions<TextPrompt> {
 }
 
 export default class TextPrompt extends Prompt {
-	valueWithCursor = '';
+	get valueWithCursor() {
+		if (this.state === 'submit') {
+			return this.value;
+		}
+		if (this.cursor >= this.value.length) {
+			return `${this.value}${color.inverse(color.hidden('_'))}`;
+		}
+		const s1 = this.value.slice(0, this.cursor);
+		const [s2, ...s3] = this.value.slice(this.cursor);
+		return `${s1}${color.inverse(s2)}${s3.join('')}`;
+	}
 	get cursor() {
 		return this._cursor;
 	}
@@ -17,16 +27,6 @@ export default class TextPrompt extends Prompt {
 		this.on('finalize', () => {
 			if (!this.value) {
 				this.value = opts.defaultValue;
-			}
-			this.valueWithCursor = this.value;
-		});
-		this.on('value', () => {
-			if (this.cursor >= this.value.length) {
-				this.valueWithCursor = `${this.value}${color.inverse(color.hidden('_'))}`;
-			} else {
-				const s1 = this.value.slice(0, this.cursor);
-				const s2 = this.value.slice(this.cursor);
-				this.valueWithCursor = `${s1}${color.inverse(s2[0])}${s2.slice(1)}`;
 			}
 		});
 	}


### PR DESCRIPTION
Previously, the cursor position for `TextPrompt` was rendered as off-by-one.

By moving the cursor logic from a `on('value')` handler to a `get valueWithCursor()` property, the cursor position will be correctly calculated as the `valueWithCursor` property is accessed.