### PR TITLE
Use block character as cursor placeholder

### DIFF
--- a/.changeset/red-glasses-grin.md
+++ b/.changeset/red-glasses-grin.md
@@ -1,0 +1,5 @@
+---
+"@clack/core": patch
+---
+
+Fixes a cursor display bug in terminals that do not support the "hidden" escape sequence. See [Issue #127](https://github.com/bombshell-dev/clack/issues/127).

--- a/packages/core/src/prompts/text.ts
+++ b/packages/core/src/prompts/text.ts
@@ -12,7 +12,7 @@ export default class TextPrompt extends Prompt {
 			return this.value;
 		}
 		if (this.cursor >= this.value.length) {
-			return `${this.value}${color.inverse(color.hidden('_'))}`;
+			return `${this.value}█`;
 		}
 		const s1 = this.value.slice(0, this.cursor);
 		const [s2, ...s3] = this.value.slice(this.cursor);


### PR DESCRIPTION
Some terminals don't support the `hidden` escape sequence, which leaves the `_` character visible. This PR switches to the `█` character, which should work everywhere.

Unfortunately, a regular space (` `) doesn't seem to display a background color when it's the last character on a line.

Closes #127.