### PR TITLE
Exports `Option` type

### DIFF
--- a/.changeset/orange-olives-yell.md
+++ b/.changeset/orange-olives-yell.md
@@ -1,0 +1,5 @@
+---
+"@clack/prompts": patch
+---
+
+Exports the `Option` type and improves JSDocannotations

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -209,9 +209,43 @@ export const confirm = (opts: ConfirmOptions) => {
 
 type Primitive = Readonly<string | boolean | number>;
 
-type Option<Value> = Value extends Primitive
-	? { value: Value; label?: string; hint?: string }
-	: { value: Value; label: string; hint?: string };
+export type Option<Value> = Value extends Primitive
+	? {
+			/**
+			 * Internal data for this option.
+			 */
+			value: Value;
+			/**
+			 * The optional, user-facing text for this option.
+			 *
+			 * By default, the `value` is converted to a string.
+			 */
+			label?: string;
+			/**
+			 * An optional hint to display to the user when
+			 * this option might be selected.
+			 *
+			 * By default, no `hint` is displayed.
+			 */
+			hint?: string;
+		}
+	: {
+			/**
+			 * Internal data for this option.
+			 */
+			value: Value;
+			/**
+			 * Required. The user-facing text for this option.
+			 */
+			label: string;
+			/**
+			 * An optional hint to display to the user when
+			 * this option might be selected.
+			 *
+			 * By default, no `hint` is displayed.
+			 */
+			hint?: string;
+		};
 
 export interface SelectOptions<Value> {
 	message: string;


### PR DESCRIPTION
`@clack/prompts` now exports the `Option` type. Also took the opportunity to add JSDoc annotations for the different values.

Closes #228.