### PR TITLE
fix: remove types condition

### DIFF
--- a/.changeset/breezy-trees-fetch.md
+++ b/.changeset/breezy-trees-fetch.md
@@ -1,0 +1,6 @@
+---
+"@clack/prompts": patch
+"@clack/core": patch
+---
+
+Fix types export

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,7 +6,6 @@
   "module": "./dist/index.mjs",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -6,7 +6,6 @@
   "module": "./dist/index.mjs",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },


### PR DESCRIPTION
The types condition can't be used for both ESM and CJS entrypoints, they need to be separated.

- https://publint.dev/@clack/core@0.4.1
- https://arethetypeswrong.github.io/?p=%40clack%2Fcore%400.4.1

Removing the types condition can fix this as it'll resolve to `./dist/index.mjs` or `./dist/index.cjs`, and then TypeScript can infer the sibiling `./dist/index.d.mts` and `./dist/index.d.cts` files automatically (both already published). Explicitly specifying two types condition is also possible but this change felt simpler.