### PR TITLE
fix: uv_tty_init error on Windows

### DIFF
--- a/.changeset/lemon-monkeys-help.md
+++ b/.changeset/lemon-monkeys-help.md
@@ -1,0 +1,5 @@
+---
+"@clack/core": patch
+---
+
+Fix "TTY initialization failed: uv_tty_init returned EBADF (bad file descriptor)" error happening on Windows for non-tty terminals.

--- a/packages/core/src/prompts/prompt.ts
+++ b/packages/core/src/prompts/prompt.ts
@@ -1,7 +1,7 @@
 import { stdin, stdout } from 'node:process';
 import readline, { type Key, type ReadLine } from 'node:readline';
-import type { Readable, Writable } from 'node:stream';
-import { WriteStream } from 'node:tty';
+import type { Readable } from 'node:stream';
+import { Writable } from 'node:stream';
 import { cursor, erase } from 'sisteransi';
 import wrap from 'wrap-ansi';
 
@@ -133,7 +133,7 @@ export default class Prompt {
 				);
 			}
 
-			const sink = new WriteStream(0);
+			const sink = new Writable();
 			sink._write = (chunk, encoding, done) => {
 				if (this._track) {
 					this.value = this.rl?.line.replace(/\t/g, '');
@@ -150,6 +150,7 @@ export default class Prompt {
 				tabSize: 2,
 				prompt: '',
 				escapeCodeTimeout: 50,
+				terminal: true,
 			});
 			readline.emitKeypressEvents(this.input, this.rl);
 			this.rl.prompt();


### PR DESCRIPTION
This PR fixes the following error happening on Windows for non-tty terminals.

> TTY initialization failed: uv_tty_init returned EBADF (bad file descriptor)

The error was happening this line.
https://github.com/bombshell-dev/clack/blob/d6d9ce791e33dbd40191a47f12db74d19bfbdb8d/packages/core/src/prompts/prompt.ts#L136
It seems calling `new tty.WriteStream` with non-tty file descriptor throws the error above.

I changed `tty.WriteStream` with `stream.Writable` and set `terminal: true` option for `readline.createInterface` so that readline will treat `stream.Writable` as a terminal.

I first went with replacing `new WriteStream(0)` with `isatty(0) ? new WriteStream(0) : fs.createWriteStream(null, { fd: 0 })`. It worked locally, but that didn't pass the tests.

refs #192
