### PR TITLE
fix: export missing types from @clack/core

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,15 @@
 export type { ClackState as State } from './types';
 export type { ClackSettings } from './utils/settings';
 
+export type { ConfirmOptions } from './prompts/confirm';
+export type { GroupMultiSelectOptions } from './prompts/group-multiselect';
+export type { MultiSelectOptions } from './prompts/multi-select';
+export type { PasswordOptions } from './prompts/password';
+export type { PromptOptions } from './prompts/prompt';
+export type { SelectOptions } from './prompts/select';
+export type { SelectKeyOptions } from './prompts/select-key';
+export type { TextOptions } from './prompts/text';
+
 export { default as ConfirmPrompt } from './prompts/confirm';
 export { default as GroupMultiSelectPrompt } from './prompts/group-multiselect';
 export { default as MultiSelectPrompt } from './prompts/multi-select';

--- a/packages/core/src/prompts/confirm.ts
+++ b/packages/core/src/prompts/confirm.ts
@@ -1,11 +1,12 @@
 import { cursor } from 'sisteransi';
 import Prompt, { type PromptOptions } from './prompt';
 
-interface ConfirmOptions extends PromptOptions<ConfirmPrompt> {
+export interface ConfirmOptions extends PromptOptions<ConfirmPrompt> {
 	active: string;
 	inactive: string;
 	initialValue?: boolean;
 }
+
 export default class ConfirmPrompt extends Prompt {
 	get cursor() {
 		return this.value ? 0 : 1;

--- a/packages/core/src/prompts/group-multiselect.ts
+++ b/packages/core/src/prompts/group-multiselect.ts
@@ -1,12 +1,13 @@
 import Prompt, { type PromptOptions } from './prompt';
 
-interface GroupMultiSelectOptions<T extends { value: any }>
+export interface GroupMultiSelectOptions<T extends { value: any }>
 	extends PromptOptions<GroupMultiSelectPrompt<T>> {
 	options: Record<string, T[]>;
 	initialValues?: T['value'][];
 	required?: boolean;
 	cursorAt?: T['value'];
 }
+
 export default class GroupMultiSelectPrompt<T extends { value: any }> extends Prompt {
 	options: (T & { group: string | boolean })[];
 	cursor = 0;

--- a/packages/core/src/prompts/multi-select.ts
+++ b/packages/core/src/prompts/multi-select.ts
@@ -1,11 +1,13 @@
 import Prompt, { type PromptOptions } from './prompt';
 
-interface MultiSelectOptions<T extends { value: any }> extends PromptOptions<MultiSelectPrompt<T>> {
+export interface MultiSelectOptions<T extends { value: any }>
+	extends PromptOptions<MultiSelectPrompt<T>> {
 	options: T[];
 	initialValues?: T['value'][];
 	required?: boolean;
 	cursorAt?: T['value'];
 }
+
 export default class MultiSelectPrompt<T extends { value: any }> extends Prompt {
 	options: T[];
 	cursor = 0;

--- a/packages/core/src/prompts/password.ts
+++ b/packages/core/src/prompts/password.ts
@@ -1,9 +1,10 @@
 import color from 'picocolors';
 import Prompt, { type PromptOptions } from './prompt';
 
-interface PasswordOptions extends PromptOptions<PasswordPrompt> {
+export interface PasswordOptions extends PromptOptions<PasswordPrompt> {
 	mask?: string;
 }
+
 export default class PasswordPrompt extends Prompt {
 	valueWithCursor = '';
 	private _mask = '•';

--- a/packages/core/src/prompts/select-key.ts
+++ b/packages/core/src/prompts/select-key.ts
@@ -1,8 +1,10 @@
 import Prompt, { type PromptOptions } from './prompt';
 
-interface SelectKeyOptions<T extends { value: any }> extends PromptOptions<SelectKeyPrompt<T>> {
+export interface SelectKeyOptions<T extends { value: any }>
+	extends PromptOptions<SelectKeyPrompt<T>> {
 	options: T[];
 }
+
 export default class SelectKeyPrompt<T extends { value: any }> extends Prompt {
 	options: T[];
 	cursor = 0;

--- a/packages/core/src/prompts/select.ts
+++ b/packages/core/src/prompts/select.ts
@@ -1,9 +1,10 @@
 import Prompt, { type PromptOptions } from './prompt';
 
-interface SelectOptions<T extends { value: any }> extends PromptOptions<SelectPrompt<T>> {
+export interface SelectOptions<T extends { value: any }> extends PromptOptions<SelectPrompt<T>> {
 	options: T[];
 	initialValue?: T['value'];
 }
+
 export default class SelectPrompt<T extends { value: any }> extends Prompt {
 	options: T[];
 	cursor = 0;


### PR DESCRIPTION
## Scope

- [x] Export missing `*Options` types for `@clack/core` prompts

## Why is it needed
I wanted to customize the behavior of `select` prompt but noticed that the generic `*option` types like `PromptOptions` are not exported.