### PR TITLE
chore: update repository url

### DIFF
--- a/examples/basic/spinner-ci.ts
+++ b/examples/basic/spinner-ci.ts
@@ -7,7 +7,7 @@
  * - There will be no loading dots animation, instead it will be always `...`
  * - Instead of erase the previous message, action that is blocked during CI, it will just write a new one.
  *
- * Issue: https://github.com/natemoo-re/clack/issues/168
+ * Issue: https://github.com/bombshell-dev/clack/issues/168
  */
 import * as p from '@clack/prompts';
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,13 +15,13 @@
   "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/natemoo-re/clack",
+    "url": "git+https://github.com/bombshell-dev/clack.git",
     "directory": "packages/core"
   },
   "bugs": {
-    "url": "https://github.com/natemoo-re/clack/issues"
+    "url": "https://github.com/bombshell-dev/clack/issues"
   },
-  "homepage": "https://github.com/natemoo-re/clack/tree/main/packages/core#readme",
+  "homepage": "https://github.com/bombshell-dev/clack/tree/main/packages/core#readme",
   "files": ["dist", "CHANGELOG.md"],
   "keywords": [
     "ask",

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -61,7 +61,7 @@ export function block({
 		input.off('keypress', clear);
 		if (hideCursor) output.write(cursor.show);
 
-		// Prevent Windows specific issues: https://github.com/natemoo-re/clack/issues/176
+		// Prevent Windows specific issues: https://github.com/bombshell-dev/clack/issues/176
 		if (input.isTTY && !isWindows) input.setRawMode(false);
 
 		// @ts-expect-error fix for https://github.com/nodejs/node/issues/31762#issuecomment-1441223907

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -2,7 +2,7 @@
 
 Effortlessly build beautiful command-line apps 🪄 [Try the demo](https://stackblitz.com/edit/clack-prompts?file=index.js)
 
-![clack-prompt](https://github.com/natemoo-re/clack/blob/main/.github/assets/clack-demo.gif)
+![clack-prompt](https://github.com/bombshell-dev/clack/blob/main/.github/assets/clack-demo.gif)
 
 ---
 
@@ -204,4 +204,4 @@ stream.error((function *() { yield 'Error!'; })());
 stream.message((function *() { yield 'Hello'; yield ", World" })(), { symbol: color.cyan('~') });
 ```
 
-[clack-log-prompts](https://github.com/natemoo-re/clack/blob/main/.github/assets/clack-logs.png)
+[clack-log-prompts](https://github.com/bombshell-dev/clack/blob/main/.github/assets/clack-logs.png)

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -15,13 +15,13 @@
   "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/natemoo-re/clack",
+    "url": "git+https://github.com/bombshell-dev/clack.git",
     "directory": "packages/prompts"
   },
   "bugs": {
-    "url": "https://github.com/natemoo-re/clack/issues"
+    "url": "https://github.com/bombshell-dev/clack/issues"
   },
-  "homepage": "https://github.com/natemoo-re/clack/tree/main/packages/prompts#readme",
+  "homepage": "https://github.com/bombshell-dev/clack/tree/main/packages/prompts#readme",
   "files": ["dist", "CHANGELOG.md"],
   "author": {
     "name": "Nate Moore",


### PR DESCRIPTION
Update from https://github.com/natemoo-re/clack to https://github.com/bombshell-dev/clack

I also updated the `repository.url` in `package.json` with `git+` and `.git` as it's recommended by npm: https://docs.npmjs.com/cli/v11/configuring-npm/package-json#repository