### PR TITLE
fix(@clack/prompts): handle spinner.stop call when spinner.start was not called

### DIFF
--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -729,7 +729,7 @@ export const spinner = ({ indicator = 'dots' }: SpinnerOptions = {}) => {
 	const delay = unicode ? 80 : 120;
 	const isCI = process.env.CI === 'true';
 
-	let unblock: () => void;
+	let unblock: (() => void) | undefined;
 	let loop: NodeJS.Timeout;
 	let isSpinnerActive = false;
 	let _message = '';
@@ -830,7 +830,7 @@ export const spinner = ({ indicator = 'dots' }: SpinnerOptions = {}) => {
 			process.stdout.write(`${step}  ${_message}\n`);
 		}
 		clearHooks();
-		unblock();
+		unblock?.();
 	};
 
 	const message = (msg = ''): void => {


### PR DESCRIPTION
Basic reproduction would be

```ts
const spin = spinner();
try {
  await doSomethingWithAnotherSpinnerInsideAndThrows();
  spin.start('loading do');
  await doSomething()
  spin.stop('success!')
} catch(error) {
  spin.stop('error!', 2)
  handleError(error)
}
```