### PR TITLE
docs(prompts): fix logs image display

### DIFF
--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -204,4 +204,4 @@ stream.error((function *() { yield 'Error!'; })());
 stream.message((function *() { yield 'Hello'; yield ", World" })(), { symbol: color.cyan('~') });
 ```
 
-[clack-log-prompts](https://github.com/bombshell-dev/clack/blob/main/.github/assets/clack-logs.png)
+![clack-log-prompts](https://github.com/bombshell-dev/clack/blob/main/.github/assets/clack-logs.png)


### PR DESCRIPTION
I've noticed that the image showcasing different `log` fuctions isn't displaying correctly. This pull request addresses the syntax issue to ensure the image appears as intended.