### PR TITLE
fix: weaken internal group types to strengthen return/onCancel types

### DIFF
--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -844,16 +844,12 @@ export const spinner = ({ indicator = 'dots' }: SpinnerOptions = {}) => {
 	};
 };
 
-export type PromptGroupAwaitedReturn<T> = {
-	[P in keyof T]: Exclude<Awaited<T[P]>, symbol>;
-};
-
 export interface PromptGroupOptions<T> {
 	/**
 	 * Control how the group can be canceled
 	 * if one of the prompts is canceled.
 	 */
-	onCancel?: (opts: { results: Prettify<Partial<PromptGroupAwaitedReturn<T>>> }) => void;
+	onCancel?: (opts: { results: Prettify<Partial<T>> }) => void;
 }
 
 type Prettify<T> = {
@@ -862,7 +858,7 @@ type Prettify<T> = {
 
 export type PromptGroup<T> = {
 	[P in keyof T]: (opts: {
-		results: Prettify<Partial<PromptGroupAwaitedReturn<Omit<T, P>>>>;
+		results: Record<PropertyKey, unknown>;
 	}) => undefined | Promise<T[P] | undefined>;
 };
 
@@ -873,7 +869,7 @@ export type PromptGroup<T> = {
 export const group = async <T>(
 	prompts: PromptGroup<T>,
 	opts?: PromptGroupOptions<T>
-): Promise<Prettify<PromptGroupAwaitedReturn<T>>> => {
+): Promise<Prettify<T>> => {
 	const results = {} as any;
 	const promptNames = Object.keys(prompts);
 


### PR DESCRIPTION
This changes a few things.

First of all, trying to infer `T` while defining `T` currently doesn't work unless there's a member without the `results` arg. This is a known limitation that may or may not be fixed in typescript one day.

Until that happens, if ever, this dumbs down the type of `results` to be a `Record<PropertyKey, unknown>`. This means _within a function_ you lose strong typing, but the return type will now always be correct.

Secondly, `T` is actually the resulting already-awaited shape. This means we do not need `Awaited<T[K]>` since `T[K]` is already the awaited type.

For example:

```ts
type ActualType = {
  foo: number;
  bar: number;
};
group<ActualType>({
  foo: () => Promise.resolve(303),
  bar: () => Promise.resolve(808)
});
```

You can see the `ActualType` never needed `Awaited<T[K]>` on each type since it is already the final result.