### PR TITLE
feat!: move to esm-only

### DIFF
--- a/.changeset/legal-bags-tie.md
+++ b/.changeset/legal-bags-tie.md
@@ -1,0 +1,8 @@
+---
+"@clack/prompts": major
+"@clack/core": major
+---
+
+The package is now distributed as ESM-only. In `v0` releases, the package was dual-published as CJS and ESM.
+
+For existing CJS projects using Node v20+, please see Node's guide on [Loading ECMAScript modules using `require()`](https://nodejs.org/docs/latest-v20.x/api/modules.html#loading-ecmascript-modules-using-require).

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,4 +18,5 @@ jobs:
           node-version: 20
           cache: "pnpm"
       - run: pnpm install
+      - run: pnpm build
       - run: pnpm type-check

--- a/build.preset.ts
+++ b/build.preset.ts
@@ -6,7 +6,7 @@ export default definePreset({
 	declaration: true,
 	sourcemap: true,
 	rollup: {
-		emitCJS: true,
+		emitCJS: false,
 		inlineDependencies: true,
 		esbuild: {
 			minify: true,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,13 +2,12 @@
   "name": "@clack/core",
   "version": "0.4.1",
   "type": "module",
-  "main": "./dist/index.cjs",
+  "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,13 +1,13 @@
-export type { ClackState as State } from './types';
-export type { ClackSettings } from './utils/settings';
+export type { ClackState as State } from './types.js';
+export type { ClackSettings } from './utils/settings.js';
 
-export { default as ConfirmPrompt } from './prompts/confirm';
-export { default as GroupMultiSelectPrompt } from './prompts/group-multiselect';
-export { default as MultiSelectPrompt } from './prompts/multi-select';
-export { default as PasswordPrompt } from './prompts/password';
-export { default as Prompt } from './prompts/prompt';
-export { default as SelectPrompt } from './prompts/select';
-export { default as SelectKeyPrompt } from './prompts/select-key';
-export { default as TextPrompt } from './prompts/text';
-export { block, isCancel } from './utils';
-export { updateSettings } from './utils/settings';
+export { default as ConfirmPrompt } from './prompts/confirm.js';
+export { default as GroupMultiSelectPrompt } from './prompts/group-multiselect.js';
+export { default as MultiSelectPrompt } from './prompts/multi-select.js';
+export { default as PasswordPrompt } from './prompts/password.js';
+export { default as Prompt } from './prompts/prompt.js';
+export { default as SelectPrompt } from './prompts/select.js';
+export { default as SelectKeyPrompt } from './prompts/select-key.js';
+export { default as TextPrompt } from './prompts/text.js';
+export { block, isCancel } from './utils/index.js';
+export { updateSettings } from './utils/settings.js';

--- a/packages/core/src/prompts/confirm.ts
+++ b/packages/core/src/prompts/confirm.ts
@@ -1,5 +1,5 @@
 import { cursor } from 'sisteransi';
-import Prompt, { type PromptOptions } from './prompt';
+import Prompt, { type PromptOptions } from './prompt.js';
 
 interface ConfirmOptions extends PromptOptions<ConfirmPrompt> {
 	active: string;

--- a/packages/core/src/prompts/group-multiselect.ts
+++ b/packages/core/src/prompts/group-multiselect.ts
@@ -1,4 +1,4 @@
-import Prompt, { type PromptOptions } from './prompt';
+import Prompt, { type PromptOptions } from './prompt.js';
 
 interface GroupMultiSelectOptions<T extends { value: any }>
 	extends PromptOptions<GroupMultiSelectPrompt<T>> {

--- a/packages/core/src/prompts/multi-select.ts
+++ b/packages/core/src/prompts/multi-select.ts
@@ -1,4 +1,4 @@
-import Prompt, { type PromptOptions } from './prompt';
+import Prompt, { type PromptOptions } from './prompt.js';
 
 interface MultiSelectOptions<T extends { value: any }> extends PromptOptions<MultiSelectPrompt<T>> {
 	options: T[];

--- a/packages/core/src/prompts/password.ts
+++ b/packages/core/src/prompts/password.ts
@@ -1,5 +1,5 @@
 import color from 'picocolors';
-import Prompt, { type PromptOptions } from './prompt';
+import Prompt, { type PromptOptions } from './prompt.js';
 
 interface PasswordOptions extends PromptOptions<PasswordPrompt> {
 	mask?: string;

--- a/packages/core/src/prompts/prompt.ts
+++ b/packages/core/src/prompts/prompt.ts
@@ -5,10 +5,10 @@ import { WriteStream } from 'node:tty';
 import { cursor, erase } from 'sisteransi';
 import wrap from 'wrap-ansi';
 
-import { CANCEL_SYMBOL, diffLines, isActionKey, setRawMode, settings } from '../utils';
+import { CANCEL_SYMBOL, diffLines, isActionKey, setRawMode, settings } from '../utils/index.js';
 
-import type { ClackEvents, ClackState } from '../types';
-import type { Action } from '../utils';
+import type { ClackEvents, ClackState } from '../types.js';
+import type { Action } from '../utils/index.js';
 
 export interface PromptOptions<Self extends Prompt> {
 	render(this: Omit<Self, 'prompt'>): string | undefined;

--- a/packages/core/src/prompts/select-key.ts
+++ b/packages/core/src/prompts/select-key.ts
@@ -1,4 +1,4 @@
-import Prompt, { type PromptOptions } from './prompt';
+import Prompt, { type PromptOptions } from './prompt.js';
 
 interface SelectKeyOptions<T extends { value: any }> extends PromptOptions<SelectKeyPrompt<T>> {
 	options: T[];

--- a/packages/core/src/prompts/select.ts
+++ b/packages/core/src/prompts/select.ts
@@ -1,4 +1,4 @@
-import Prompt, { type PromptOptions } from './prompt';
+import Prompt, { type PromptOptions } from './prompt.js';
 
 interface SelectOptions<T extends { value: any }> extends PromptOptions<SelectPrompt<T>> {
 	options: T[];

--- a/packages/core/src/prompts/text.ts
+++ b/packages/core/src/prompts/text.ts
@@ -1,5 +1,5 @@
 import color from 'picocolors';
-import Prompt, { type PromptOptions } from './prompt';
+import Prompt, { type PromptOptions } from './prompt.js';
 
 export interface TextOptions extends PromptOptions<TextPrompt> {
 	placeholder?: string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,4 @@
-import type { Action } from './utils/settings';
+import type { Action } from './utils/settings.js';
 
 /**
  * The state of the prompt

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -3,10 +3,10 @@ import type { Key } from 'node:readline';
 import * as readline from 'node:readline';
 import type { Readable } from 'node:stream';
 import { cursor } from 'sisteransi';
-import { isActionKey } from './settings';
+import { isActionKey } from './settings.js';
 
-export * from './string';
-export * from './settings';
+export * from './string.js';
+export * from './settings.js';
 
 const isWindows = globalThis.process.platform.startsWith('win');
 

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -2,13 +2,12 @@
   "name": "@clack/prompts",
   "version": "0.10.0",
   "type": "module",
-  "main": "./dist/index.cjs",
+  "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.mjs"
     },
     "./package.json": "./package.json"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
 packages:
   - 'examples/**'
-  - 'packages/**/*'
+  - 'packages/*'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,9 @@
 {
   "compilerOptions": {
     "noEmit": true,
-    "module": "ESNext",
+    "module": "node16",
     "target": "ESNext",
-    "moduleResolution": "Bundler",
-    "moduleDetection": "force",
+    "moduleResolution": "node16",
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Migrates to emitting only ES modules now that `require(esm)` is supported in all LTS versions of node other than the soon-to-die-off 18.x.