### PR TITLE
feat(@clack/prompts): custom spinner indicator support

### DIFF
--- a/.changeset/thin-socks-travel.md
+++ b/.changeset/thin-socks-travel.md
@@ -1,0 +1,5 @@
+---
+"@clack/prompts": minor
+---
+
+Support for custom spinner

--- a/.changeset/thin-socks-travel.md
+++ b/.changeset/thin-socks-travel.md
@@ -2,4 +2,4 @@
 "@clack/prompts": minor
 ---
 
-Support for custom spinner
+Added support for custom frames in spinner prompt

--- a/packages/prompts/src/spinner.ts
+++ b/packages/prompts/src/spinner.ts
@@ -12,7 +12,7 @@ import {
 } from './common.js';
 
 export interface SpinnerOptions extends CommonOptions {
-	indicator?: 'dots' | 'timer' | "custom";
+	indicator?: 'dots' | 'timer';
 	onCancel?: () => void;
 	cancelMessage?: string;
 	errorMessage?: string;
@@ -33,10 +33,10 @@ export const spinner = ({
 	output = process.stdout,
 	cancelMessage,
 	errorMessage,
-	...props
+	frames = unicode ? ['◒', '◐', '◓', '◑'] : ['•', 'o', 'O', '0'],
+	delay = unicode ? 80 : 120,
 }: SpinnerOptions = {}): SpinnerResult => {
-	const frames = props.frames ? props.frames : unicode ?  ['◒', '◐', '◓', '◑'] : ['•', 'o', 'O', '0'];
-	const delay = props.delay ? props.delay : unicode ? 80 : 120;
+
 	const isCI = isCIFn();
 
 	let unblock: () => void;

--- a/packages/prompts/src/spinner.ts
+++ b/packages/prompts/src/spinner.ts
@@ -12,10 +12,12 @@ import {
 } from './common.js';
 
 export interface SpinnerOptions extends CommonOptions {
-	indicator?: 'dots' | 'timer';
+	indicator?: 'dots' | 'timer' | "custom";
 	onCancel?: () => void;
 	cancelMessage?: string;
 	errorMessage?: string;
+	frames?: string[];
+	delay?: number;
 }
 
 export interface SpinnerResult {
@@ -31,9 +33,10 @@ export const spinner = ({
 	output = process.stdout,
 	cancelMessage,
 	errorMessage,
+	...props
 }: SpinnerOptions = {}): SpinnerResult => {
-	const frames = unicode ? ['◒', '◐', '◓', '◑'] : ['•', 'o', 'O', '0'];
-	const delay = unicode ? 80 : 120;
+	const frames = props.frames ? props.frames : unicode ?  ['◒', '◐', '◓', '◑'] : ['•', 'o', 'O', '0'];
+	const delay = props.delay ? props.delay : unicode ? 80 : 120;
 	const isCI = isCIFn();
 
 	let unblock: () => void;

--- a/packages/prompts/src/spinner.ts
+++ b/packages/prompts/src/spinner.ts
@@ -36,7 +36,6 @@ export const spinner = ({
 	frames = unicode ? ['◒', '◐', '◓', '◑'] : ['•', 'o', 'O', '0'],
 	delay = unicode ? 80 : 120,
 }: SpinnerOptions = {}): SpinnerResult => {
-
 	const isCI = isCIFn();
 
 	let unblock: () => void;

--- a/packages/prompts/test/__snapshots__/spinner.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/spinner.test.ts.snap
@@ -2,42 +2,42 @@
 
 exports[`spinner (isCI = false) > indicator customization > custom delay 1`] = `
 [
-  "[?25l",
+  "<cursor.hide>",
   "[90m│[39m
 ",
   "[35m◒[39m  ",
-  "[999D",
-  "[J",
+  "<cursor.backward count=999>",
+  "<erase.down>",
   "[35m◐[39m  ",
-  "[999D",
-  "[J",
+  "<cursor.backward count=999>",
+  "<erase.down>",
   "[35m◓[39m  ",
-  "[999D",
-  "[J",
+  "<cursor.backward count=999>",
+  "<erase.down>",
   "[35m◑[39m  ",
 ]
 `;
 
 exports[`spinner (isCI = false) > indicator customization > custom frames 1`] = `
 [
-  "[?25l",
+  "<cursor.hide>",
   "[90m│[39m
 ",
   "[35m🐴[39m  ",
-  "[999D",
-  "[J",
+  "<cursor.backward count=999>",
+  "<erase.down>",
   "[35m🦋[39m  ",
-  "[999D",
-  "[J",
+  "<cursor.backward count=999>",
+  "<erase.down>",
   "[35m🐙[39m  ",
-  "[999D",
-  "[J",
+  "<cursor.backward count=999>",
+  "<erase.down>",
   "[35m🐶[39m  ",
-  "[999D",
-  "[J",
+  "<cursor.backward count=999>",
+  "<erase.down>",
   "[32m◇[39m  
 ",
-  "[?25h",
+  "<cursor.show>",
 ]
 `;
 
@@ -50,11 +50,11 @@ exports[`spinner (isCI = false) > message > sets message for next frame 1`] = `
   "<cursor.backward count=999>",
   "<erase.down>",
   "[35m◐[39m  foo",
-  "[999D",
-  "[J",
+  "<cursor.backward count=999>",
+  "<erase.down>",
   "[32m◇[39m  
 ",
-  "[?25h",
+  "<cursor.show>",
 ]
 `;
 
@@ -243,7 +243,7 @@ exports[`spinner (isCI = false) > stop > renders submit symbol and stops spinner
 
 exports[`spinner (isCI = true) > indicator customization > custom delay 1`] = `
 [
-  "[?25l",
+  "<cursor.hide>",
   "[90m│[39m
 ",
   "[35m◒[39m  ...",
@@ -252,17 +252,17 @@ exports[`spinner (isCI = true) > indicator customization > custom delay 1`] = `
 
 exports[`spinner (isCI = true) > indicator customization > custom frames 1`] = `
 [
-  "[?25l",
+  "<cursor.hide>",
   "[90m│[39m
 ",
   "[35m🐴[39m  ...",
   "
 ",
-  "[999D",
-  "[J",
+  "<cursor.backward count=999>",
+  "<erase.down>",
   "[32m◇[39m  
 ",
-  "[?25h",
+  "<cursor.show>",
 ]
 `;
 
@@ -279,11 +279,11 @@ exports[`spinner (isCI = true) > message > sets message for next frame 1`] = `
   "[35m◐[39m  foo...",
   "
 ",
-  "[999D",
-  "[J",
+  "<cursor.backward count=999>",
+  "<erase.down>",
   "[32m◇[39m  
 ",
-  "[?25h",
+  "<cursor.show>",
 ]
 `;
 

--- a/packages/prompts/test/__snapshots__/spinner.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/spinner.test.ts.snap
@@ -15,6 +15,11 @@ exports[`spinner (isCI = false) > indicator customization > custom delay 1`] = `
   "<cursor.backward count=999>",
   "<erase.down>",
   "[35m◑[39m  ",
+  "<cursor.backward count=999>",
+  "<erase.down>",
+  "[32m◇[39m  
+",
+  "<cursor.show>",
 ]
 `;
 
@@ -33,6 +38,11 @@ exports[`spinner (isCI = false) > indicator customization > custom frames 1`] = 
   "<cursor.backward count=999>",
   "<erase.down>",
   "[35m🐶[39m  ",
+  "<cursor.backward count=999>",
+  "<erase.down>",
+  "[32m◇[39m  
+",
+  "<cursor.show>",
 ]
 `;
 
@@ -45,6 +55,11 @@ exports[`spinner (isCI = false) > message > sets message for next frame 1`] = `
   "<cursor.backward count=999>",
   "<erase.down>",
   "[35m◐[39m  foo",
+  "<cursor.backward count=999>",
+  "<erase.down>",
+  "[32m◇[39m  
+",
+  "<cursor.show>",
 ]
 `;
 
@@ -140,6 +155,11 @@ exports[`spinner (isCI = false) > start > renders frames at interval 1`] = `
   "<cursor.backward count=999>",
   "<erase.down>",
   "[35m◑[39m  ",
+  "<cursor.backward count=999>",
+  "<erase.down>",
+  "[32m◇[39m  
+",
+  "<cursor.show>",
 ]
 `;
 
@@ -149,6 +169,11 @@ exports[`spinner (isCI = false) > start > renders message 1`] = `
   "[90m│[39m
 ",
   "[35m◒[39m  foo",
+  "<cursor.backward count=999>",
+  "<erase.down>",
+  "[32m◇[39m  
+",
+  "<cursor.show>",
 ]
 `;
 
@@ -158,6 +183,11 @@ exports[`spinner (isCI = false) > start > renders timer when indicator is "timer
   "[90m│[39m
 ",
   "[35m◒[39m   [0s]",
+  "<cursor.backward count=999>",
+  "<erase.down>",
+  "[32m◇[39m   [0s]
+",
+  "<cursor.show>",
 ]
 `;
 
@@ -237,6 +267,13 @@ exports[`spinner (isCI = true) > indicator customization > custom delay 1`] = `
   "[90m│[39m
 ",
   "[35m◒[39m  ...",
+  "
+",
+  "<cursor.backward count=999>",
+  "<erase.down>",
+  "[32m◇[39m  
+",
+  "<cursor.show>",
 ]
 `;
 
@@ -246,6 +283,13 @@ exports[`spinner (isCI = true) > indicator customization > custom frames 1`] = `
   "[90m│[39m
 ",
   "[35m🐴[39m  ...",
+  "
+",
+  "<cursor.backward count=999>",
+  "<erase.down>",
+  "[32m◇[39m  
+",
+  "<cursor.show>",
 ]
 `;
 
@@ -260,6 +304,13 @@ exports[`spinner (isCI = true) > message > sets message for next frame 1`] = `
   "<cursor.backward count=999>",
   "<erase.down>",
   "[35m◐[39m  foo...",
+  "
+",
+  "<cursor.backward count=999>",
+  "<erase.down>",
+  "[32m◇[39m  
+",
+  "<cursor.show>",
 ]
 `;
 
@@ -346,6 +397,13 @@ exports[`spinner (isCI = true) > start > renders frames at interval 1`] = `
   "[90m│[39m
 ",
   "[35m◒[39m  ...",
+  "
+",
+  "<cursor.backward count=999>",
+  "<erase.down>",
+  "[32m◇[39m  
+",
+  "<cursor.show>",
 ]
 `;
 
@@ -355,6 +413,13 @@ exports[`spinner (isCI = true) > start > renders message 1`] = `
   "[90m│[39m
 ",
   "[35m◒[39m  foo...",
+  "
+",
+  "<cursor.backward count=999>",
+  "<erase.down>",
+  "[32m◇[39m  
+",
+  "<cursor.show>",
 ]
 `;
 
@@ -364,6 +429,13 @@ exports[`spinner (isCI = true) > start > renders timer when indicator is "timer"
   "[90m│[39m
 ",
   "[35m◒[39m  ...",
+  "
+",
+  "<cursor.backward count=999>",
+  "<erase.down>",
+  "[32m◇[39m   [0s]
+",
+  "<cursor.show>",
 ]
 `;
 

--- a/packages/prompts/test/__snapshots__/spinner.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/spinner.test.ts.snap
@@ -24,6 +24,15 @@ exports[`spinner (isCI = false) > indicator customization > custom frames 1`] = 
   "[90m│[39m
 ",
   "[35m🐴[39m  ",
+  "[999D",
+  "[J",
+  "[35m🦋[39m  ",
+  "[999D",
+  "[J",
+  "[35m🐙[39m  ",
+  "[999D",
+  "[J",
+  "[35m🐶[39m  ",
 ]
 `;
 

--- a/packages/prompts/test/__snapshots__/spinner.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/spinner.test.ts.snap
@@ -15,6 +15,11 @@ exports[`spinner (isCI = false) > indicator customization > custom delay 1`] = `
   "<cursor.backward count=999>",
   "<erase.down>",
   "[35m◑[39m  ",
+  "<cursor.backward count=999>",
+  "<erase.down>",
+  "[32m◇[39m  
+",
+  "<cursor.show>",
 ]
 `;
 
@@ -247,6 +252,13 @@ exports[`spinner (isCI = true) > indicator customization > custom delay 1`] = `
   "[90m│[39m
 ",
   "[35m◒[39m  ...",
+  "
+",
+  "<cursor.backward count=999>",
+  "<erase.down>",
+  "[32m◇[39m  
+",
+  "<cursor.show>",
 ]
 `;
 

--- a/packages/prompts/test/__snapshots__/spinner.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/spinner.test.ts.snap
@@ -1,5 +1,32 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`spinner (isCI = false) > indicator customization > custom delay 1`] = `
+[
+  "[?25l",
+  "[90m│[39m
+",
+  "[35m◒[39m  ",
+  "[999D",
+  "[J",
+  "[35m◐[39m  ",
+  "[999D",
+  "[J",
+  "[35m◓[39m  ",
+  "[999D",
+  "[J",
+  "[35m◑[39m  ",
+]
+`;
+
+exports[`spinner (isCI = false) > indicator customization > custom frames 1`] = `
+[
+  "[?25l",
+  "[90m│[39m
+",
+  "[35m🐴[39m  ",
+]
+`;
+
 exports[`spinner (isCI = false) > message > sets message for next frame 1`] = `
 [
   "<cursor.hide>",
@@ -192,6 +219,24 @@ exports[`spinner (isCI = false) > stop > renders submit symbol and stops spinner
   "[32m◇[39m  
 ",
   "<cursor.show>",
+]
+`;
+
+exports[`spinner (isCI = true) > indicator customization > custom delay 1`] = `
+[
+  "[?25l",
+  "[90m│[39m
+",
+  "[35m◒[39m  ...",
+]
+`;
+
+exports[`spinner (isCI = true) > indicator customization > custom frames 1`] = `
+[
+  "[?25l",
+  "[90m│[39m
+",
+  "[35m🐴[39m  ...",
 ]
 `;
 

--- a/packages/prompts/test/__snapshots__/spinner.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/spinner.test.ts.snap
@@ -15,11 +15,6 @@ exports[`spinner (isCI = false) > indicator customization > custom delay 1`] = `
   "<cursor.backward count=999>",
   "<erase.down>",
   "[35m◑[39m  ",
-  "<cursor.backward count=999>",
-  "<erase.down>",
-  "[32m◇[39m  
-",
-  "<cursor.show>",
 ]
 `;
 
@@ -38,11 +33,6 @@ exports[`spinner (isCI = false) > indicator customization > custom frames 1`] = 
   "<cursor.backward count=999>",
   "<erase.down>",
   "[35m🐶[39m  ",
-  "<cursor.backward count=999>",
-  "<erase.down>",
-  "[32m◇[39m  
-",
-  "<cursor.show>",
 ]
 `;
 
@@ -55,11 +45,6 @@ exports[`spinner (isCI = false) > message > sets message for next frame 1`] = `
   "<cursor.backward count=999>",
   "<erase.down>",
   "[35m◐[39m  foo",
-  "<cursor.backward count=999>",
-  "<erase.down>",
-  "[32m◇[39m  
-",
-  "<cursor.show>",
 ]
 `;
 
@@ -252,13 +237,6 @@ exports[`spinner (isCI = true) > indicator customization > custom delay 1`] = `
   "[90m│[39m
 ",
   "[35m◒[39m  ...",
-  "
-",
-  "<cursor.backward count=999>",
-  "<erase.down>",
-  "[32m◇[39m  
-",
-  "<cursor.show>",
 ]
 `;
 
@@ -268,13 +246,6 @@ exports[`spinner (isCI = true) > indicator customization > custom frames 1`] = `
   "[90m│[39m
 ",
   "[35m🐴[39m  ...",
-  "
-",
-  "<cursor.backward count=999>",
-  "<erase.down>",
-  "[32m◇[39m  
-",
-  "<cursor.show>",
 ]
 `;
 
@@ -289,13 +260,6 @@ exports[`spinner (isCI = true) > message > sets message for next frame 1`] = `
   "<cursor.backward count=999>",
   "<erase.down>",
   "[35m◐[39m  foo...",
-  "
-",
-  "<cursor.backward count=999>",
-  "<erase.down>",
-  "[32m◇[39m  
-",
-  "<cursor.show>",
 ]
 `;
 

--- a/packages/prompts/test/__snapshots__/spinner.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/spinner.test.ts.snap
@@ -33,6 +33,11 @@ exports[`spinner (isCI = false) > indicator customization > custom frames 1`] = 
   "[999D",
   "[J",
   "[35m🐶[39m  ",
+  "[999D",
+  "[J",
+  "[32m◇[39m  
+",
+  "[?25h",
 ]
 `;
 
@@ -45,6 +50,11 @@ exports[`spinner (isCI = false) > message > sets message for next frame 1`] = `
   "<cursor.backward count=999>",
   "<erase.down>",
   "[35m◐[39m  foo",
+  "[999D",
+  "[J",
+  "[32m◇[39m  
+",
+  "[?25h",
 ]
 `;
 
@@ -246,6 +256,13 @@ exports[`spinner (isCI = true) > indicator customization > custom frames 1`] = `
   "[90m│[39m
 ",
   "[35m🐴[39m  ...",
+  "
+",
+  "[999D",
+  "[J",
+  "[32m◇[39m  
+",
+  "[?25h",
 ]
 `;
 
@@ -260,6 +277,13 @@ exports[`spinner (isCI = true) > message > sets message for next frame 1`] = `
   "<cursor.backward count=999>",
   "<erase.down>",
   "[35m◐[39m  foo...",
+  "
+",
+  "[999D",
+  "[J",
+  "[32m◇[39m  
+",
+  "[?25h",
 ]
 `;
 

--- a/packages/prompts/test/spinner.test.ts
+++ b/packages/prompts/test/spinner.test.ts
@@ -176,6 +176,8 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 			for (let i = 0; i < 4; i++) {
 				vi.advanceTimersByTime(200);
 			}
+			
+			result.stop();
 
 			expect(output.buffer).toMatchSnapshot();
 		});

--- a/packages/prompts/test/spinner.test.ts
+++ b/packages/prompts/test/spinner.test.ts
@@ -45,9 +45,10 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 				vi.advanceTimersByTime(80);
 			}
 
+			result.stop();
+			
 			expect(output.buffer).toMatchSnapshot();
 
-			result.stop();
 		});
 
 		test('renders message', () => {
@@ -57,9 +58,10 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 
 			vi.advanceTimersByTime(80);
 
+			result.stop();
+
 			expect(output.buffer).toMatchSnapshot();
 
-			result.stop();
 		});
 
 		test('renders timer when indicator is "timer"', () => {
@@ -69,9 +71,10 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 
 			vi.advanceTimersByTime(80);
 
+			result.stop();
+
 			expect(output.buffer).toMatchSnapshot();
 
-			result.stop();
 		});
 	});
 
@@ -151,9 +154,10 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 
 			vi.advanceTimersByTime(80);
 
+			result.stop();
+
 			expect(output.buffer).toMatchSnapshot();
 
-			result.stop();
 		});
 	});
 
@@ -168,9 +172,10 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 				vi.advanceTimersByTime(80);
 			}
 
+			result.stop();
+
 			expect(output.buffer).toMatchSnapshot();
 
-			result.stop();
 		});
 
 		test('custom delay', () => {
@@ -183,9 +188,10 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 				vi.advanceTimersByTime(200);
 			}
 			
+			result.stop();
+
 			expect(output.buffer).toMatchSnapshot();
 
-			result.stop();
 		});
 	});
 

--- a/packages/prompts/test/spinner.test.ts
+++ b/packages/prompts/test/spinner.test.ts
@@ -145,6 +145,8 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 
 			vi.advanceTimersByTime(80);
 
+			result.stop();
+			
 			expect(output.buffer).toMatchSnapshot();
 		});
 	});
@@ -159,6 +161,8 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 			for (let i = 0; i < 4; i++) {
 				vi.advanceTimersByTime(80);
 			}
+
+			result.stop();
 
 			expect(output.buffer).toMatchSnapshot();
 		});

--- a/packages/prompts/test/spinner.test.ts
+++ b/packages/prompts/test/spinner.test.ts
@@ -155,7 +155,10 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 
 			result.start();
 
-			vi.advanceTimersByTime(80);
+			// there are 4 frames
+			for (let i = 0; i < 4; i++) {
+				vi.advanceTimersByTime(80);
+			}
 
 			expect(output.buffer).toMatchSnapshot();
 		});

--- a/packages/prompts/test/spinner.test.ts
+++ b/packages/prompts/test/spinner.test.ts
@@ -46,6 +46,8 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 			}
 
 			expect(output.buffer).toMatchSnapshot();
+
+			result.stop();
 		});
 
 		test('renders message', () => {
@@ -56,6 +58,8 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 			vi.advanceTimersByTime(80);
 
 			expect(output.buffer).toMatchSnapshot();
+
+			result.stop();
 		});
 
 		test('renders timer when indicator is "timer"', () => {
@@ -66,6 +70,8 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 			vi.advanceTimersByTime(80);
 
 			expect(output.buffer).toMatchSnapshot();
+
+			result.stop();
 		});
 	});
 
@@ -145,9 +151,9 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 
 			vi.advanceTimersByTime(80);
 
-			result.stop();
-			
 			expect(output.buffer).toMatchSnapshot();
+
+			result.stop();
 		});
 	});
 
@@ -162,9 +168,9 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 				vi.advanceTimersByTime(80);
 			}
 
-			result.stop();
-
 			expect(output.buffer).toMatchSnapshot();
+
+			result.stop();
 		});
 
 		test('custom delay', () => {
@@ -177,9 +183,9 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 				vi.advanceTimersByTime(200);
 			}
 			
-			result.stop();
-
 			expect(output.buffer).toMatchSnapshot();
+
+			result.stop();
 		});
 	});
 

--- a/packages/prompts/test/spinner.test.ts
+++ b/packages/prompts/test/spinner.test.ts
@@ -46,9 +46,8 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 			}
 
 			result.stop();
-			
-			expect(output.buffer).toMatchSnapshot();
 
+			expect(output.buffer).toMatchSnapshot();
 		});
 
 		test('renders message', () => {
@@ -61,7 +60,6 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 			result.stop();
 
 			expect(output.buffer).toMatchSnapshot();
-
 		});
 
 		test('renders timer when indicator is "timer"', () => {
@@ -74,7 +72,6 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 			result.stop();
 
 			expect(output.buffer).toMatchSnapshot();
-
 		});
 	});
 
@@ -157,7 +154,6 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 			result.stop();
 
 			expect(output.buffer).toMatchSnapshot();
-
 		});
 	});
 
@@ -175,7 +171,6 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 			result.stop();
 
 			expect(output.buffer).toMatchSnapshot();
-
 		});
 
 		test('custom delay', () => {
@@ -187,11 +182,10 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 			for (let i = 0; i < 4; i++) {
 				vi.advanceTimersByTime(200);
 			}
-			
+
 			result.stop();
 
 			expect(output.buffer).toMatchSnapshot();
-
 		});
 	});
 

--- a/packages/prompts/test/spinner.test.ts
+++ b/packages/prompts/test/spinner.test.ts
@@ -149,6 +149,31 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 		});
 	});
 
+	describe('indicator customization', () => {
+		test('custom frames', () => {
+			const result = prompts.spinner({ output, frames: ['🐴', '🦋', '🐙', '🐶'] });
+
+			result.start();
+
+			vi.advanceTimersByTime(80);
+
+			expect(output.buffer).toMatchSnapshot();
+		});
+
+		test('custom delay', () => {
+			const result = prompts.spinner({ output, delay: 200 });
+
+			result.start();
+
+			// there are 4 frames
+			for (let i = 0; i < 4; i++) {
+				vi.advanceTimersByTime(200);
+			}
+
+			expect(output.buffer).toMatchSnapshot();
+		});
+	});
+
 	describe('process exit handling', () => {
 		let processEmitter: EventEmitter;
 


### PR DESCRIPTION
# Custom Spinner Support
Great work on clack! I was eager to have a custom spinner option so I figured I could contribute back to the project. Happy to adjust the implementation if not conform requirements.

Supports a 'custom' indicator on the spinner for settings custom frames and speed:
```ts
export const customSpinner = spinner({
	indicator: "custom",
	custom: {
		frames: ["🦨", "🐎", "🌵", "🤠", "💘", "🧨", "🌮", "🥃", "🏜️"],
		speed: 500,
	},
});
```