### PR TITLE
chore: v1-alpha

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,11 @@
+{
+  "mode": "pre",
+  "tag": "alpha",
+  "initialVersions": {
+    "@example/basic": "0.0.0",
+    "@example/changesets": "0.0.0",
+    "@clack/core": "0.4.1",
+    "@clack/prompts": "0.10.0"
+  },
+  "changesets": []
+}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 <h4 align="center"><a href="packages/prompts#readme"><code>@clack/prompts</code></a>: beautiful, ready-to-use CLI prompt components</h4>
 
 > [!WARNING]
-> Clack's `main` branch is tracking the `alpha` release line for `v1.0.0+`. To view the relatively stable `v0` line, please browse the [v0](https://github.com/bombshell-dev/clack/tree/v0) branch.
+> Clack's `main` branch is tracking the [`alpha` release line for `v1.0.0+`](https://github.com/bombshell-dev/clack/pull/250). To view the relatively stable `v0` line, please browse the [v0](https://github.com/bombshell-dev/clack/tree/v0) branch.
 
 <br />
 <br />

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@
 <h4 align="center"><a href="packages/core#readme"><code>@clack/core</code></a>: unstyled, extensible primitives for CLIs</h4>
 <h4 align="center"><a href="packages/prompts#readme"><code>@clack/prompts</code></a>: beautiful, ready-to-use CLI prompt components</h4>
 
+> [!WARNING]
+> Clack's `main` branch is tracking the `alpha` release line for `v1.0.0+`. To view the relatively stable `v0` line, please browse the [v0](https://github.com/bombshell-dev/clack/tree/v0) branch.
+
 <br />
 <br />
 


### PR DESCRIPTION
This PR enters `alpha` pre-release mode on `main`.

### Why jump to v1? 

While there hasn't been much activity on this project recently, many projects have already adopted the `v0` releases in production. Although semantic versioning allows for breaking changes on the minor release of the `v0` major, this wouldn't provide a very stable experience for our existing users.

By moving to the `alpha` pre-release, we're clearly indicating that this is a new chapter for Clack.

### What happens to v0 releases?

We plan to backport critical bug fixes to the [`v0`](https://github.com/bombshell-dev/clack/tree/v0) branch, but don't expect to release any more `v0` minors with new features or breaking changes.