### PR TITLE
refactor: remove duplicated types

### DIFF
--- a/build.preset.ts
+++ b/build.preset.ts
@@ -3,7 +3,7 @@ import { definePreset } from 'unbuild';
 // @see https://github.com/unjs/unbuild
 export default definePreset({
 	clean: true,
-	declaration: true,
+	declaration: 'node16',
 	sourcemap: true,
 	rollup: {
 		emitCJS: false,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,12 +6,12 @@
   "module": "./dist/index.mjs",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/index.d.mts",
       "default": "./dist/index.mjs"
     },
     "./package.json": "./package.json"
   },
-  "types": "./dist/index.d.ts",
+  "types": "./dist/index.d.mts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/bombshell-dev/clack.git",

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -6,12 +6,12 @@
   "module": "./dist/index.mjs",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/index.d.mts",
       "default": "./dist/index.mjs"
     },
     "./package.json": "./package.json"
   },
-  "types": "./dist/index.d.ts",
+  "types": "./dist/index.d.mts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/bombshell-dev/clack.git",


### PR DESCRIPTION
There was `dist/index.d.ts` and `dist/index.d.mts` with the same content. With this PR, only `index.d.mts` is kept. As `"types"` is using `.d.mts`, only [TypeScript 4.7](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#new-file-extensions) and above will work, which I think should be ok considering that it's nearly 3 years ago and we're modernizing the package.

Ideally sticking with `index.d.ts` and removing `index.d.mts` could help with compatibility, but it doesn't seem configurable with unbuild.