### PR TITLE
ci: skip running preview workflow in forks

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 
 jobs:
   build:
+    if: github.repository == 'bombshell-dev/clack'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
In my fork branch I got [an error](https://github.com/bluwy/clack/actions/runs/14132909943/job/39597513003) when running the preview workflow. A repo check should help prevent it and potentially mistakenly publishing it if someone has pkg.pr.new app setup.

