### PR TITLE
feat: add `groupSpacing` option to group multi select

### DIFF
--- a/.changeset/happy-parents-explain.md
+++ b/.changeset/happy-parents-explain.md
@@ -2,4 +2,4 @@
 "@clack/prompts": minor
 ---
 
-Added `groupSpacing` to control spacing between multi select groups.
+Adds a new `groupSpacing` option to grouped multi-select prompts. If set to an integer greater than 0, it will add that number of new lines between each group.

--- a/.changeset/happy-parents-explain.md
+++ b/.changeset/happy-parents-explain.md
@@ -1,0 +1,5 @@
+---
+"@clack/prompts": minor
+---
+
+Added `groupSpacing` to control spacing between multi select groups.

--- a/packages/prompts/src/__snapshots__/index.test.ts.snap
+++ b/packages/prompts/src/__snapshots__/index.test.ts.snap
@@ -380,6 +380,94 @@ exports[`prompts (isCI = false) > groupMultiselect > cursorAt sets initial selec
 ]
 `;
 
+exports[`prompts (isCI = false) > groupMultiselect > groupSpacing > negative spacing is ignored 1`] = `
+[
+  "[?25l",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [2m[22m[36m◻[39m group1
+[36m│[39m  └ [36m◻[39m [2mgroup1value0[22m
+[36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup2value0[22m
+[36m└[39m
+",
+  "[999D[7A",
+  "[2B",
+  "[J",
+  "[36m│[39m  [2m[22m[2m◻[22m [2mgroup1[22m
+[36m│[39m  [2m└ [22m[36m◻[39m group1value0
+[36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup2value0[22m
+[36m└[39m
+",
+  "[999D[7A",
+  "[2B",
+  "[J",
+  "[36m│[39m  [2m[22m[32m◼[39m [2mgroup1[22m
+[36m│[39m  [2m└ [22m[32m◼[39m group1value0
+[36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup2value0[22m
+[36m└[39m
+",
+  "[999D[7A",
+  "[1B",
+  "[J",
+  "[32m◇[39m  foo
+[90m│[39m  [2mgroup1value0[22m",
+  "
+",
+  "[?25h",
+]
+`;
+
+exports[`prompts (isCI = false) > groupMultiselect > groupSpacing > renders spaced groups 1`] = `
+[
+  "[?25l",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m
+[36m│[39m
+[36m│[39m  [2m[22m[36m◻[39m group1
+[36m│[39m  └ [36m◻[39m [2mgroup1value0[22m
+[36m│[39m
+[36m│[39m
+[36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup2value0[22m
+[36m└[39m
+",
+  "[999D[11A",
+  "[4B",
+  "[J",
+  "[36m│[39m  [2m[22m[2m◻[22m [2mgroup1[22m
+[36m│[39m  [2m└ [22m[36m◻[39m group1value0
+[36m│[39m
+[36m│[39m
+[36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup2value0[22m
+[36m└[39m
+",
+  "[999D[11A",
+  "[4B",
+  "[J",
+  "[36m│[39m  [2m[22m[32m◼[39m [2mgroup1[22m
+[36m│[39m  [2m└ [22m[32m◼[39m group1value0
+[36m│[39m
+[36m│[39m
+[36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup2value0[22m
+[36m└[39m
+",
+  "[999D[11A",
+  "[1B",
+  "[J",
+  "[32m◇[39m  foo
+[90m│[39m  [2mgroup1value0[22m",
+  "
+",
+  "[?25h",
+]
+`;
+
 exports[`prompts (isCI = false) > groupMultiselect > initial values can be set 1`] = `
 [
   "[?25l",
@@ -2148,6 +2236,94 @@ exports[`prompts (isCI = true) > groupMultiselect > cursorAt sets initial select
   "[J",
   "[32m◇[39m  foo
 [90m│[39m  [2mgroup1value1[22m",
+  "
+",
+  "[?25h",
+]
+`;
+
+exports[`prompts (isCI = true) > groupMultiselect > groupSpacing > negative spacing is ignored 1`] = `
+[
+  "[?25l",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [2m[22m[36m◻[39m group1
+[36m│[39m  └ [36m◻[39m [2mgroup1value0[22m
+[36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup2value0[22m
+[36m└[39m
+",
+  "[999D[7A",
+  "[2B",
+  "[J",
+  "[36m│[39m  [2m[22m[2m◻[22m [2mgroup1[22m
+[36m│[39m  [2m└ [22m[36m◻[39m group1value0
+[36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup2value0[22m
+[36m└[39m
+",
+  "[999D[7A",
+  "[2B",
+  "[J",
+  "[36m│[39m  [2m[22m[32m◼[39m [2mgroup1[22m
+[36m│[39m  [2m└ [22m[32m◼[39m group1value0
+[36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup2value0[22m
+[36m└[39m
+",
+  "[999D[7A",
+  "[1B",
+  "[J",
+  "[32m◇[39m  foo
+[90m│[39m  [2mgroup1value0[22m",
+  "
+",
+  "[?25h",
+]
+`;
+
+exports[`prompts (isCI = true) > groupMultiselect > groupSpacing > renders spaced groups 1`] = `
+[
+  "[?25l",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m
+[36m│[39m
+[36m│[39m  [2m[22m[36m◻[39m group1
+[36m│[39m  └ [36m◻[39m [2mgroup1value0[22m
+[36m│[39m
+[36m│[39m
+[36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup2value0[22m
+[36m└[39m
+",
+  "[999D[11A",
+  "[4B",
+  "[J",
+  "[36m│[39m  [2m[22m[2m◻[22m [2mgroup1[22m
+[36m│[39m  [2m└ [22m[36m◻[39m group1value0
+[36m│[39m
+[36m│[39m
+[36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup2value0[22m
+[36m└[39m
+",
+  "[999D[11A",
+  "[4B",
+  "[J",
+  "[36m│[39m  [2m[22m[32m◼[39m [2mgroup1[22m
+[36m│[39m  [2m└ [22m[32m◼[39m group1value0
+[36m│[39m
+[36m│[39m
+[36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup2value0[22m
+[36m└[39m
+",
+  "[999D[11A",
+  "[1B",
+  "[J",
+  "[32m◇[39m  foo
+[90m│[39m  [2mgroup1value0[22m",
   "
 ",
   "[?25h",

--- a/packages/prompts/src/index.test.ts
+++ b/packages/prompts/src/index.test.ts
@@ -1204,5 +1204,49 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 			expect(value).toEqual([value0]);
 			expect(output.buffer).toMatchSnapshot();
 		});
+
+		describe('groupSpacing', () => {
+			test('renders spaced groups', async () => {
+				const result = prompts.groupMultiselect({
+					message: 'foo',
+					input,
+					output,
+					options: {
+						group1: [{ value: 'group1value0' }],
+						group2: [{ value: 'group2value0' }],
+					},
+					groupSpacing: 2,
+				});
+
+				input.emit('keypress', '', { name: 'down' });
+				input.emit('keypress', '', { name: 'space' });
+				input.emit('keypress', '', { name: 'return' });
+
+				await result;
+
+				expect(output.buffer).toMatchSnapshot();
+			});
+
+			test('negative spacing is ignored', async () => {
+				const result = prompts.groupMultiselect({
+					message: 'foo',
+					input,
+					output,
+					options: {
+						group1: [{ value: 'group1value0' }],
+						group2: [{ value: 'group2value0' }],
+					},
+					groupSpacing: -2,
+				});
+
+				input.emit('keypress', '', { name: 'down' });
+				input.emit('keypress', '', { name: 'space' });
+				input.emit('keypress', '', { name: 'return' });
+
+				await result;
+
+				expect(output.buffer).toMatchSnapshot();
+			});
+		});
 	});
 });

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -489,9 +489,10 @@ export interface GroupMultiSelectOptions<Value> extends CommonOptions {
 	required?: boolean;
 	cursorAt?: Value;
 	selectableGroups?: boolean;
+	groupSpacing?: number;
 }
 export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) => {
-	const { selectableGroups = true } = opts;
+	const { selectableGroups = true, groupSpacing = 0 } = opts;
 	const opt = (
 		option: Option<Value>,
 		state:
@@ -510,21 +511,23 @@ export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) =>
 		const next = isItem && (options[options.indexOf(option) + 1] ?? { group: true });
 		const isLast = isItem && (next as any).group === true;
 		const prefix = isItem ? (selectableGroups ? `${isLast ? S_BAR_END : S_BAR} ` : '  ') : '';
+		const spacingPrefix =
+			groupSpacing > 0 && !isItem ? `\n${color.cyan(S_BAR)}  `.repeat(groupSpacing) : '';
 
 		if (state === 'active') {
-			return `${color.dim(prefix)}${color.cyan(S_CHECKBOX_ACTIVE)} ${label} ${
+			return `${spacingPrefix}${color.dim(prefix)}${color.cyan(S_CHECKBOX_ACTIVE)} ${label} ${
 				option.hint ? color.dim(`(${option.hint})`) : ''
 			}`;
 		}
 		if (state === 'group-active') {
-			return `${prefix}${color.cyan(S_CHECKBOX_ACTIVE)} ${color.dim(label)}`;
+			return `${spacingPrefix}${prefix}${color.cyan(S_CHECKBOX_ACTIVE)} ${color.dim(label)}`;
 		}
 		if (state === 'group-active-selected') {
-			return `${prefix}${color.green(S_CHECKBOX_SELECTED)} ${color.dim(label)}`;
+			return `${spacingPrefix}${prefix}${color.green(S_CHECKBOX_SELECTED)} ${color.dim(label)}`;
 		}
 		if (state === 'selected') {
 			const selectedCheckbox = isItem || selectableGroups ? color.green(S_CHECKBOX_SELECTED) : '';
-			return `${color.dim(prefix)}${selectedCheckbox} ${color.dim(label)} ${
+			return `${spacingPrefix}${color.dim(prefix)}${selectedCheckbox} ${color.dim(label)} ${
 				option.hint ? color.dim(`(${option.hint})`) : ''
 			}`;
 		}
@@ -532,7 +535,7 @@ export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) =>
 			return `${color.strikethrough(color.dim(label))}`;
 		}
 		if (state === 'active-selected') {
-			return `${color.dim(prefix)}${color.green(S_CHECKBOX_SELECTED)} ${label} ${
+			return `${spacingPrefix}${color.dim(prefix)}${color.green(S_CHECKBOX_SELECTED)} ${label} ${
 				option.hint ? color.dim(`(${option.hint})`) : ''
 			}`;
 		}
@@ -540,7 +543,7 @@ export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) =>
 			return `${color.dim(label)}`;
 		}
 		const unselectedCheckbox = isItem || selectableGroups ? color.dim(S_CHECKBOX_INACTIVE) : '';
-		return `${color.dim(prefix)}${unselectedCheckbox} ${color.dim(label)}`;
+		return `${spacingPrefix}${color.dim(prefix)}${unselectedCheckbox} ${color.dim(label)}`;
 	};
 
 	return new GroupMultiSelectPrompt({


### PR DESCRIPTION
Adds a `groupSpacing` option.

If set to something more than `0`, it adds spacing between the groups.

This is another svelte port. They have `spacedGroups` but I decided to make it a little more flexible here