### PR TITLE
chore(ci): allow release from v0 branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,7 @@ name: Release
 
 on:
   push:
-    branches:
-      - main
+    branches: [main, v0]
 
 permissions:
   contents: write


### PR DESCRIPTION
Adding the `v0` branch to our release workflow for backports