### PR TITLE
feat: add `CommonOptions` so all prompts accept a custom output/input

### DIFF
--- a/.changeset/healthy-candles-admire.md
+++ b/.changeset/healthy-candles-admire.md
@@ -1,0 +1,5 @@
+---
+"@clack/prompts": patch
+---
+
+Updates all prompts to accept a custom `output` and `input` stream


### PR DESCRIPTION
Allows all prompts to take a custom `output` or `input` which defaults to `process.stdout` and `process.stdin` respectively.