### PR TITLE
feat: add taskLog prompt

### DIFF
--- a/.changeset/famous-turkeys-burn.md
+++ b/.changeset/famous-turkeys-burn.md
@@ -1,0 +1,5 @@
+---
+"@clack/prompts": minor
+---
+
+Added new `taskLog` prompt for log output which is cleared on success

--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -204,4 +204,26 @@ stream.error((function *() { yield 'Error!'; })());
 stream.message((function *() { yield 'Hello'; yield ", World" })(), { symbol: color.cyan('~') });
 ```
 
+### Task Log
+
+When executing a sub-process or a similar sub-task, `taskLog` can be used to render the output continuously and clear it at the end if it was successful.
+
+```js
+import { taskLog } from '@clack/prompts';
+
+const log = taskLog({
+	message: 'Running npm install'
+});
+
+for await (const line of npmInstall()) {
+	log.message(line);
+}
+
+if (success) {
+	log.success('Done!');
+} else {
+	log.error('Failed!');
+}
+```
+
 ![clack-log-prompts](https://github.com/bombshell-dev/clack/blob/main/.github/assets/clack-logs.png)

--- a/packages/prompts/src/__snapshots__/index.test.ts.snap
+++ b/packages/prompts/src/__snapshots__/index.test.ts.snap
@@ -1598,8 +1598,8 @@ exports[`prompts (isCI = false) > taskLog > message > can write multiple lines 1
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  [2mline 0
-[2m│[22m  line 1[22m
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
 ",
 ]
 `;
@@ -1625,7 +1625,7 @@ exports[`prompts (isCI = false) > taskLog > message > enforces limit if set 1`] 
 ]
 `;
 
-exports[`prompts (isCI = false) > taskLog > message > handles empty lines 1`] = `
+exports[`prompts (isCI = false) > taskLog > message > prints empty lines 1`] = `
 [
   "[2m│[22m
 ",
@@ -1635,18 +1635,14 @@ exports[`prompts (isCI = false) > taskLog > message > handles empty lines 1`] = 
 ",
   "[2m│[22m  [2m[22m
 ",
-  "[2K[1A[2K[G",
-  "[2m│[22m  [2m[22m
-[2m│[22m  [2mline 1[22m
+  "[2m│[22m  [2mline 1[22m
 ",
-  "[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  [2m[22m
-[2m│[22m  [2mline 1[22m
+  "[2K[1A[2K[G",
+  "[2m│[22m  [2mline 1[22m
 [2m│[22m  [2m[22m
 ",
-  "[2K[1A[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  [2m[22m
-[2m│[22m  [2mline 1[22m
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 1[22m
 [2m│[22m  [2m[22m
 [2m│[22m  [2mline 3[22m
 ",
@@ -1664,11 +1660,11 @@ exports[`prompts (isCI = false) > taskLog > message > raw = true appends message
   "[2m│[22m  [2mline 0[22m
 ",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m[2mstill line 0[22m
+  "[2m│[22m  [2mline 0still line 0[22m
 ",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m[2mstill line 0[22m[2m
-[2m│[22m  line 1[22m
+  "[2m│[22m  [2mline 0still line 0[22m
+[2m│[22m  [2mline 1[22m
 ",
 ]
 `;
@@ -1684,10 +1680,10 @@ exports[`prompts (isCI = false) > taskLog > message > raw = true works when mixe
   "[2m│[22m  [2mline 0[22m
 ",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m[2mstill line 0[22m
+  "[2m│[22m  [2mline 0still line 0[22m
 ",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m[2mstill line 0[22m
+  "[2m│[22m  [2mline 0still line 0[22m
 [2m│[22m  [2mline 1[22m
 ",
 ]
@@ -1709,7 +1705,7 @@ exports[`prompts (isCI = false) > taskLog > message > raw = true works when star
 ",
   "[2K[1A[2K[1A[2K[G",
   "[2m│[22m  [2mline 0[22m
-[2m│[22m  [2mline 1[22m[2mstill line 1[22m
+[2m│[22m  [2mline 1still line 1[22m
 ",
 ]
 `;
@@ -3935,8 +3931,8 @@ exports[`prompts (isCI = true) > taskLog > message > can write multiple lines 1`
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  [2mline 0
-[2m│[22m  line 1[22m
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
 ",
 ]
 `;
@@ -3962,7 +3958,7 @@ exports[`prompts (isCI = true) > taskLog > message > enforces limit if set 1`] =
 ]
 `;
 
-exports[`prompts (isCI = true) > taskLog > message > handles empty lines 1`] = `
+exports[`prompts (isCI = true) > taskLog > message > prints empty lines 1`] = `
 [
   "[2m│[22m
 ",
@@ -3972,18 +3968,14 @@ exports[`prompts (isCI = true) > taskLog > message > handles empty lines 1`] = `
 ",
   "[2m│[22m  [2m[22m
 ",
-  "[2K[1A[2K[G",
-  "[2m│[22m  [2m[22m
-[2m│[22m  [2mline 1[22m
+  "[2m│[22m  [2mline 1[22m
 ",
-  "[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  [2m[22m
-[2m│[22m  [2mline 1[22m
+  "[2K[1A[2K[G",
+  "[2m│[22m  [2mline 1[22m
 [2m│[22m  [2m[22m
 ",
-  "[2K[1A[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  [2m[22m
-[2m│[22m  [2mline 1[22m
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 1[22m
 [2m│[22m  [2m[22m
 [2m│[22m  [2mline 3[22m
 ",
@@ -4001,11 +3993,11 @@ exports[`prompts (isCI = true) > taskLog > message > raw = true appends message 
   "[2m│[22m  [2mline 0[22m
 ",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m[2mstill line 0[22m
+  "[2m│[22m  [2mline 0still line 0[22m
 ",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m[2mstill line 0[22m[2m
-[2m│[22m  line 1[22m
+  "[2m│[22m  [2mline 0still line 0[22m
+[2m│[22m  [2mline 1[22m
 ",
 ]
 `;
@@ -4021,10 +4013,10 @@ exports[`prompts (isCI = true) > taskLog > message > raw = true works when mixed
   "[2m│[22m  [2mline 0[22m
 ",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m[2mstill line 0[22m
+  "[2m│[22m  [2mline 0still line 0[22m
 ",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m[2mstill line 0[22m
+  "[2m│[22m  [2mline 0still line 0[22m
 [2m│[22m  [2mline 1[22m
 ",
 ]
@@ -4046,7 +4038,7 @@ exports[`prompts (isCI = true) > taskLog > message > raw = true works when start
 ",
   "[2K[1A[2K[1A[2K[G",
   "[2m│[22m  [2mline 0[22m
-[2m│[22m  [2mline 1[22m[2mstill line 1[22m
+[2m│[22m  [2mline 1still line 1[22m
 ",
 ]
 `;

--- a/packages/prompts/src/__snapshots__/index.test.ts.snap
+++ b/packages/prompts/src/__snapshots__/index.test.ts.snap
@@ -1527,7 +1527,7 @@ exports[`prompts (isCI = false) > spinner > stop > renders submit symbol and sto
 ]
 `;
 
-exports[`prompts (isCI = false) > taskLog > error > clears output if renderLog = false 1`] = `
+exports[`prompts (isCI = false) > taskLog > error > clears output if showLog = false 1`] = `
 [
   "[2m│[22m
 ",
@@ -2089,7 +2089,7 @@ exports[`prompts (isCI = false) > taskLog > success > clears output and renders 
 ]
 `;
 
-exports[`prompts (isCI = false) > taskLog > success > renders output if renderLog = true 1`] = `
+exports[`prompts (isCI = false) > taskLog > success > renders output if showLog = true 1`] = `
 [
   "[2m│[22m
 ",
@@ -3864,7 +3864,7 @@ exports[`prompts (isCI = true) > spinner > stop > renders submit symbol and stop
 ]
 `;
 
-exports[`prompts (isCI = true) > taskLog > error > clears output if renderLog = false 1`] = `
+exports[`prompts (isCI = true) > taskLog > error > clears output if showLog = false 1`] = `
 [
   "[2m│[22m
 ",
@@ -4426,7 +4426,7 @@ exports[`prompts (isCI = true) > taskLog > success > clears output and renders m
 ]
 `;
 
-exports[`prompts (isCI = true) > taskLog > success > renders output if renderLog = true 1`] = `
+exports[`prompts (isCI = true) > taskLog > success > renders output if showLog = true 1`] = `
 [
   "[2m│[22m
 ",

--- a/packages/prompts/src/__snapshots__/index.test.ts.snap
+++ b/packages/prompts/src/__snapshots__/index.test.ts.snap
@@ -1535,19 +1535,22 @@ exports[`prompts (isCI = false) > taskLog > error > maintains output but replace
 ",
   "[2m│[22m
 ",
-  "[2K[G",
-  "[90m│[39m  line 0
+  "[2m│[22m  line 0
+[2m│[22m
 ",
-  "[2K[1A[2K[G",
-  "[90m│[39m  line 0
-[90m│[39m  line 1
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  line 0
+[2m│[22m  line 1
+[2m│[22m
 ",
-  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
-  "[31m■[39m  some error!
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[31m■[39m  some error!
 ",
-  "[90m│[39m
-[90m│[39m  line 0
-[90m│[39m  line 1
+  "[2m│[22m
+[2m│[22m  line 0
+[2m│[22m  line 1
+[2m│[22m
 ",
 ]
 `;
@@ -1560,12 +1563,13 @@ exports[`prompts (isCI = false) > taskLog > message > can write line by line 1`]
 ",
   "[2m│[22m
 ",
-  "[2K[G",
-  "[90m│[39m  line 0
+  "[2m│[22m  line 0
+[2m│[22m
 ",
-  "[2K[1A[2K[G",
-  "[90m│[39m  line 0
-[90m│[39m  line 1
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  line 0
+[2m│[22m  line 1
+[2m│[22m
 ",
 ]
 `;
@@ -1578,9 +1582,9 @@ exports[`prompts (isCI = false) > taskLog > message > can write multiple lines 1
 ",
   "[2m│[22m
 ",
-  "[2K[G",
-  "[90m│[39m  line 0
-[90m│[39m  line 1
+  "[2m│[22m  line 0
+[2m│[22m  line 1
+[2m│[22m
 ",
 ]
 `;
@@ -1593,16 +1597,50 @@ exports[`prompts (isCI = false) > taskLog > message > enforces limit if set 1`] 
 ",
   "[2m│[22m
 ",
-  "[2K[G",
-  "[90m│[39m  line 0
-",
-  "[2K[1A[2K[G",
-  "[90m│[39m  line 0
-[90m│[39m  line 1
+  "[2m│[22m  line 0
+[2m│[22m
 ",
   "[2K[1A[2K[1A[2K[G",
-  "[90m│[39m  line 1
-[90m│[39m  line 2
+  "[2m│[22m  line 0
+[2m│[22m  line 1
+[2m│[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  line 1
+[2m│[22m  line 2
+[2m│[22m
+",
+]
+`;
+
+exports[`prompts (isCI = false) > taskLog > message > handles empty lines 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2m│[22m
+[2m│[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[2m│[22m  line 1
+[2m│[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[2m│[22m  line 1
+[2m│[22m
+[2m│[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[2m│[22m  line 1
+[2m│[22m
+[2m│[22m  line 3
+[2m│[22m
 ",
 ]
 `;
@@ -1615,15 +1653,17 @@ exports[`prompts (isCI = false) > taskLog > message > raw = true appends message
 ",
   "[2m│[22m
 ",
-  "[2K[G",
-  "[90m│[39m  line 0
+  "[2m│[22m  line 0
+[2m│[22m
 ",
-  "[2K[1A[2K[G",
-  "[90m│[39m  line 0still line 0
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  line 0still line 0
+[2m│[22m
 ",
-  "[2K[1A[2K[G",
-  "[90m│[39m  line 0still line 0
-[90m│[39m  line 1
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  line 0still line 0
+[2m│[22m  line 1
+[2m│[22m
 ",
 ]
 `;
@@ -1636,15 +1676,17 @@ exports[`prompts (isCI = false) > taskLog > message > raw = true works when mixe
 ",
   "[2m│[22m
 ",
-  "[2K[G",
-  "[90m│[39m  line 0
+  "[2m│[22m  line 0
+[2m│[22m
 ",
-  "[2K[1A[2K[G",
-  "[90m│[39m  line 0still line 0
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  line 0still line 0
+[2m│[22m
 ",
-  "[2K[1A[2K[G",
-  "[90m│[39m  line 0still line 0
-[90m│[39m  line 1
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  line 0still line 0
+[2m│[22m  line 1
+[2m│[22m
 ",
 ]
 `;
@@ -1657,16 +1699,18 @@ exports[`prompts (isCI = false) > taskLog > message > raw = true works when star
 ",
   "[2m│[22m
 ",
-  "[2K[G",
-  "[90m│[39m  line 0
-",
-  "[2K[1A[2K[G",
-  "[90m│[39m  line 0
-[90m│[39m  line 1
+  "[2m│[22m  line 0
+[2m│[22m
 ",
   "[2K[1A[2K[1A[2K[G",
-  "[90m│[39m  line 0
-[90m│[39m  line 1still line 1
+  "[2m│[22m  line 0
+[2m│[22m  line 1
+[2m│[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  line 0
+[2m│[22m  line 1still line 1
+[2m│[22m
 ",
 ]
 `;
@@ -1679,15 +1723,17 @@ exports[`prompts (isCI = false) > taskLog > success > clears output and renders 
 ",
   "[2m│[22m
 ",
-  "[2K[G",
-  "[90m│[39m  line 0
+  "[2m│[22m  line 0
+[2m│[22m
 ",
-  "[2K[1A[2K[G",
-  "[90m│[39m  line 0
-[90m│[39m  line 1
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  line 0
+[2m│[22m  line 1
+[2m│[22m
 ",
-  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
-  "[32m◆[39m  success!
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[32m◆[39m  success!
 ",
 ]
 `;
@@ -3450,19 +3496,22 @@ exports[`prompts (isCI = true) > taskLog > error > maintains output but replaces
 ",
   "[2m│[22m
 ",
-  "[2K[G",
-  "[90m│[39m  line 0
+  "[2m│[22m  line 0
+[2m│[22m
 ",
-  "[2K[1A[2K[G",
-  "[90m│[39m  line 0
-[90m│[39m  line 1
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  line 0
+[2m│[22m  line 1
+[2m│[22m
 ",
-  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
-  "[31m■[39m  some error!
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[31m■[39m  some error!
 ",
-  "[90m│[39m
-[90m│[39m  line 0
-[90m│[39m  line 1
+  "[2m│[22m
+[2m│[22m  line 0
+[2m│[22m  line 1
+[2m│[22m
 ",
 ]
 `;
@@ -3475,12 +3524,13 @@ exports[`prompts (isCI = true) > taskLog > message > can write line by line 1`] 
 ",
   "[2m│[22m
 ",
-  "[2K[G",
-  "[90m│[39m  line 0
+  "[2m│[22m  line 0
+[2m│[22m
 ",
-  "[2K[1A[2K[G",
-  "[90m│[39m  line 0
-[90m│[39m  line 1
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  line 0
+[2m│[22m  line 1
+[2m│[22m
 ",
 ]
 `;
@@ -3493,9 +3543,9 @@ exports[`prompts (isCI = true) > taskLog > message > can write multiple lines 1`
 ",
   "[2m│[22m
 ",
-  "[2K[G",
-  "[90m│[39m  line 0
-[90m│[39m  line 1
+  "[2m│[22m  line 0
+[2m│[22m  line 1
+[2m│[22m
 ",
 ]
 `;
@@ -3508,16 +3558,50 @@ exports[`prompts (isCI = true) > taskLog > message > enforces limit if set 1`] =
 ",
   "[2m│[22m
 ",
-  "[2K[G",
-  "[90m│[39m  line 0
-",
-  "[2K[1A[2K[G",
-  "[90m│[39m  line 0
-[90m│[39m  line 1
+  "[2m│[22m  line 0
+[2m│[22m
 ",
   "[2K[1A[2K[1A[2K[G",
-  "[90m│[39m  line 1
-[90m│[39m  line 2
+  "[2m│[22m  line 0
+[2m│[22m  line 1
+[2m│[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  line 1
+[2m│[22m  line 2
+[2m│[22m
+",
+]
+`;
+
+exports[`prompts (isCI = true) > taskLog > message > handles empty lines 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2m│[22m
+[2m│[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[2m│[22m  line 1
+[2m│[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[2m│[22m  line 1
+[2m│[22m
+[2m│[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[2m│[22m  line 1
+[2m│[22m
+[2m│[22m  line 3
+[2m│[22m
 ",
 ]
 `;
@@ -3530,15 +3614,17 @@ exports[`prompts (isCI = true) > taskLog > message > raw = true appends message 
 ",
   "[2m│[22m
 ",
-  "[2K[G",
-  "[90m│[39m  line 0
+  "[2m│[22m  line 0
+[2m│[22m
 ",
-  "[2K[1A[2K[G",
-  "[90m│[39m  line 0still line 0
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  line 0still line 0
+[2m│[22m
 ",
-  "[2K[1A[2K[G",
-  "[90m│[39m  line 0still line 0
-[90m│[39m  line 1
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  line 0still line 0
+[2m│[22m  line 1
+[2m│[22m
 ",
 ]
 `;
@@ -3551,15 +3637,17 @@ exports[`prompts (isCI = true) > taskLog > message > raw = true works when mixed
 ",
   "[2m│[22m
 ",
-  "[2K[G",
-  "[90m│[39m  line 0
+  "[2m│[22m  line 0
+[2m│[22m
 ",
-  "[2K[1A[2K[G",
-  "[90m│[39m  line 0still line 0
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  line 0still line 0
+[2m│[22m
 ",
-  "[2K[1A[2K[G",
-  "[90m│[39m  line 0still line 0
-[90m│[39m  line 1
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  line 0still line 0
+[2m│[22m  line 1
+[2m│[22m
 ",
 ]
 `;
@@ -3572,16 +3660,18 @@ exports[`prompts (isCI = true) > taskLog > message > raw = true works when start
 ",
   "[2m│[22m
 ",
-  "[2K[G",
-  "[90m│[39m  line 0
-",
-  "[2K[1A[2K[G",
-  "[90m│[39m  line 0
-[90m│[39m  line 1
+  "[2m│[22m  line 0
+[2m│[22m
 ",
   "[2K[1A[2K[1A[2K[G",
-  "[90m│[39m  line 0
-[90m│[39m  line 1still line 1
+  "[2m│[22m  line 0
+[2m│[22m  line 1
+[2m│[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  line 0
+[2m│[22m  line 1still line 1
+[2m│[22m
 ",
 ]
 `;
@@ -3594,15 +3684,17 @@ exports[`prompts (isCI = true) > taskLog > success > clears output and renders m
 ",
   "[2m│[22m
 ",
-  "[2K[G",
-  "[90m│[39m  line 0
+  "[2m│[22m  line 0
+[2m│[22m
 ",
-  "[2K[1A[2K[G",
-  "[90m│[39m  line 0
-[90m│[39m  line 1
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  line 0
+[2m│[22m  line 1
+[2m│[22m
 ",
-  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
-  "[32m◆[39m  success!
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[32m◆[39m  success!
 ",
 ]
 `;

--- a/packages/prompts/src/__snapshots__/index.test.ts.snap
+++ b/packages/prompts/src/__snapshots__/index.test.ts.snap
@@ -1607,6 +1607,70 @@ exports[`prompts (isCI = false) > taskLog > message > enforces limit if set 1`] 
 ]
 `;
 
+exports[`prompts (isCI = false) > taskLog > message > raw = true appends message text until newline 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2K[G",
+  "[90m│[39m  line 0
+",
+  "[2K[1A[2K[G",
+  "[90m│[39m  line 0still line 0
+",
+  "[2K[1A[2K[G",
+  "[90m│[39m  line 0still line 0
+[90m│[39m  line 1
+",
+]
+`;
+
+exports[`prompts (isCI = false) > taskLog > message > raw = true works when mixed with non-raw messages 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2K[G",
+  "[90m│[39m  line 0
+",
+  "[2K[1A[2K[G",
+  "[90m│[39m  line 0still line 0
+",
+  "[2K[1A[2K[G",
+  "[90m│[39m  line 0still line 0
+[90m│[39m  line 1
+",
+]
+`;
+
+exports[`prompts (isCI = false) > taskLog > message > raw = true works when started with non-raw messages 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2K[G",
+  "[90m│[39m  line 0
+",
+  "[2K[1A[2K[G",
+  "[90m│[39m  line 0
+[90m│[39m  line 1
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[90m│[39m  line 0
+[90m│[39m  line 1still line 1
+",
+]
+`;
+
 exports[`prompts (isCI = false) > taskLog > success > clears output and renders message 1`] = `
 [
   "[2m│[22m
@@ -3454,6 +3518,70 @@ exports[`prompts (isCI = true) > taskLog > message > enforces limit if set 1`] =
   "[2K[1A[2K[1A[2K[G",
   "[90m│[39m  line 1
 [90m│[39m  line 2
+",
+]
+`;
+
+exports[`prompts (isCI = true) > taskLog > message > raw = true appends message text until newline 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2K[G",
+  "[90m│[39m  line 0
+",
+  "[2K[1A[2K[G",
+  "[90m│[39m  line 0still line 0
+",
+  "[2K[1A[2K[G",
+  "[90m│[39m  line 0still line 0
+[90m│[39m  line 1
+",
+]
+`;
+
+exports[`prompts (isCI = true) > taskLog > message > raw = true works when mixed with non-raw messages 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2K[G",
+  "[90m│[39m  line 0
+",
+  "[2K[1A[2K[G",
+  "[90m│[39m  line 0still line 0
+",
+  "[2K[1A[2K[G",
+  "[90m│[39m  line 0still line 0
+[90m│[39m  line 1
+",
+]
+`;
+
+exports[`prompts (isCI = true) > taskLog > message > raw = true works when started with non-raw messages 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2K[G",
+  "[90m│[39m  line 0
+",
+  "[2K[1A[2K[G",
+  "[90m│[39m  line 0
+[90m│[39m  line 1
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[90m│[39m  line 0
+[90m│[39m  line 1still line 1
 ",
 ]
 `;

--- a/packages/prompts/src/__snapshots__/index.test.ts.snap
+++ b/packages/prompts/src/__snapshots__/index.test.ts.snap
@@ -1527,6 +1527,118 @@ exports[`prompts (isCI = false) > spinner > stop > renders submit symbol and sto
 ]
 `;
 
+exports[`prompts (isCI = false) > taskLog > error > maintains output but replaces message 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2K[G",
+  "[90m│[39m  line 0
+",
+  "[2K[1A[2K[G",
+  "[90m│[39m  line 0
+[90m│[39m  line 1
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[31m■[39m  some error!
+",
+  "[90m│[39m
+[90m│[39m  line 0
+[90m│[39m  line 1
+",
+]
+`;
+
+exports[`prompts (isCI = false) > taskLog > message > can write line by line 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2K[G",
+  "[90m│[39m  line 0
+",
+  "[2K[1A[2K[G",
+  "[90m│[39m  line 0
+[90m│[39m  line 1
+",
+]
+`;
+
+exports[`prompts (isCI = false) > taskLog > message > can write multiple lines 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2K[G",
+  "[90m│[39m  line 0
+[90m│[39m  line 1
+",
+]
+`;
+
+exports[`prompts (isCI = false) > taskLog > message > enforces limit if set 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2K[G",
+  "[90m│[39m  line 0
+",
+  "[2K[1A[2K[G",
+  "[90m│[39m  line 0
+[90m│[39m  line 1
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[90m│[39m  line 1
+[90m│[39m  line 2
+",
+]
+`;
+
+exports[`prompts (isCI = false) > taskLog > success > clears output and renders message 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2K[G",
+  "[90m│[39m  line 0
+",
+  "[2K[1A[2K[G",
+  "[90m│[39m  line 0
+[90m│[39m  line 1
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[32m◆[39m  success!
+",
+]
+`;
+
+exports[`prompts (isCI = false) > taskLog > writes message header 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+]
+`;
+
 exports[`prompts (isCI = false) > text > can cancel 1`] = `
 [
   "[?25l",
@@ -3263,6 +3375,118 @@ exports[`prompts (isCI = true) > spinner > stop > renders submit symbol and stop
   "[32m◇[39m  
 ",
   "[?25h",
+]
+`;
+
+exports[`prompts (isCI = true) > taskLog > error > maintains output but replaces message 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2K[G",
+  "[90m│[39m  line 0
+",
+  "[2K[1A[2K[G",
+  "[90m│[39m  line 0
+[90m│[39m  line 1
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[31m■[39m  some error!
+",
+  "[90m│[39m
+[90m│[39m  line 0
+[90m│[39m  line 1
+",
+]
+`;
+
+exports[`prompts (isCI = true) > taskLog > message > can write line by line 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2K[G",
+  "[90m│[39m  line 0
+",
+  "[2K[1A[2K[G",
+  "[90m│[39m  line 0
+[90m│[39m  line 1
+",
+]
+`;
+
+exports[`prompts (isCI = true) > taskLog > message > can write multiple lines 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2K[G",
+  "[90m│[39m  line 0
+[90m│[39m  line 1
+",
+]
+`;
+
+exports[`prompts (isCI = true) > taskLog > message > enforces limit if set 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2K[G",
+  "[90m│[39m  line 0
+",
+  "[2K[1A[2K[G",
+  "[90m│[39m  line 0
+[90m│[39m  line 1
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[90m│[39m  line 1
+[90m│[39m  line 2
+",
+]
+`;
+
+exports[`prompts (isCI = true) > taskLog > success > clears output and renders message 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2K[G",
+  "[90m│[39m  line 0
+",
+  "[2K[1A[2K[G",
+  "[90m│[39m  line 0
+[90m│[39m  line 1
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[32m◆[39m  success!
+",
+]
+`;
+
+exports[`prompts (isCI = true) > taskLog > writes message header 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
 ]
 `;
 

--- a/packages/prompts/src/__snapshots__/index.test.ts.snap
+++ b/packages/prompts/src/__snapshots__/index.test.ts.snap
@@ -1527,7 +1527,28 @@ exports[`prompts (isCI = false) > spinner > stop > renders submit symbol and sto
 ]
 `;
 
-exports[`prompts (isCI = false) > taskLog > error > maintains output but replaces message 1`] = `
+exports[`prompts (isCI = false) > taskLog > error > clears output if renderLog = false 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2m│[22m  [2mline 0[22m
+",
+  "[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[31m■[39m  some error!
+",
+]
+`;
+
+exports[`prompts (isCI = false) > taskLog > error > renders output with message 1`] = `
 [
   "[2m│[22m
 ",
@@ -1693,6 +1714,360 @@ exports[`prompts (isCI = false) > taskLog > message > raw = true works when star
 ]
 `;
 
+exports[`prompts (isCI = false) > taskLog > retainLog > error > outputs limited log with limit by default 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2m│[22m  [2mline 0[22m
+",
+  "[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[31m■[39m  woo!
+",
+  "[2m│[22m
+[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+]
+`;
+
+exports[`prompts (isCI = false) > taskLog > retainLog > error > retainLog = false outputs full log without limit 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2m│[22m  [2mline 0[22m
+",
+  "[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[31m■[39m  woo!
+",
+  "[2m│[22m
+[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+]
+`;
+
+exports[`prompts (isCI = false) > taskLog > retainLog > error > retainLog = false outputs limited log with limit 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2m│[22m  [2mline 0[22m
+",
+  "[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[31m■[39m  woo!
+",
+  "[2m│[22m
+[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+]
+`;
+
+exports[`prompts (isCI = false) > taskLog > retainLog > error > retainLog = true outputs full log 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2m│[22m  [2mline 0[22m
+",
+  "[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[31m■[39m  woo!
+",
+  "[2m│[22m
+[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+]
+`;
+
+exports[`prompts (isCI = false) > taskLog > retainLog > error > retainLog = true outputs full log with limit 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2m│[22m  [2mline 0[22m
+",
+  "[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[31m■[39m  woo!
+",
+  "[2m│[22m
+[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+]
+`;
+
+exports[`prompts (isCI = false) > taskLog > retainLog > success > outputs limited log with limit by default 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2m│[22m  [2mline 0[22m
+",
+  "[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[32m◆[39m  woo!
+",
+  "[2m│[22m
+[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+]
+`;
+
+exports[`prompts (isCI = false) > taskLog > retainLog > success > retainLog = false outputs full log without limit 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2m│[22m  [2mline 0[22m
+",
+  "[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[32m◆[39m  woo!
+",
+  "[2m│[22m
+[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+]
+`;
+
+exports[`prompts (isCI = false) > taskLog > retainLog > success > retainLog = false outputs limited log with limit 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2m│[22m  [2mline 0[22m
+",
+  "[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[32m◆[39m  woo!
+",
+  "[2m│[22m
+[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+]
+`;
+
+exports[`prompts (isCI = false) > taskLog > retainLog > success > retainLog = true outputs full log 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2m│[22m  [2mline 0[22m
+",
+  "[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[32m◆[39m  woo!
+",
+  "[2m│[22m
+[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+]
+`;
+
+exports[`prompts (isCI = false) > taskLog > retainLog > success > retainLog = true outputs full log with limit 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2m│[22m  [2mline 0[22m
+",
+  "[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[32m◆[39m  woo!
+",
+  "[2m│[22m
+[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+]
+`;
+
 exports[`prompts (isCI = false) > taskLog > success > clears output and renders message 1`] = `
 [
   "[2m│[22m
@@ -1710,6 +2085,31 @@ exports[`prompts (isCI = false) > taskLog > success > clears output and renders 
   "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
   "[2m│[22m
 [32m◆[39m  success!
+",
+]
+`;
+
+exports[`prompts (isCI = false) > taskLog > success > renders output if renderLog = true 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2m│[22m  [2mline 0[22m
+",
+  "[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[32m◆[39m  success!
+",
+  "[2m│[22m
+[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
 ",
 ]
 `;
@@ -3464,7 +3864,28 @@ exports[`prompts (isCI = true) > spinner > stop > renders submit symbol and stop
 ]
 `;
 
-exports[`prompts (isCI = true) > taskLog > error > maintains output but replaces message 1`] = `
+exports[`prompts (isCI = true) > taskLog > error > clears output if renderLog = false 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2m│[22m  [2mline 0[22m
+",
+  "[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[31m■[39m  some error!
+",
+]
+`;
+
+exports[`prompts (isCI = true) > taskLog > error > renders output with message 1`] = `
 [
   "[2m│[22m
 ",
@@ -3630,6 +4051,360 @@ exports[`prompts (isCI = true) > taskLog > message > raw = true works when start
 ]
 `;
 
+exports[`prompts (isCI = true) > taskLog > retainLog > error > outputs limited log with limit by default 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2m│[22m  [2mline 0[22m
+",
+  "[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[31m■[39m  woo!
+",
+  "[2m│[22m
+[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+]
+`;
+
+exports[`prompts (isCI = true) > taskLog > retainLog > error > retainLog = false outputs full log without limit 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2m│[22m  [2mline 0[22m
+",
+  "[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[31m■[39m  woo!
+",
+  "[2m│[22m
+[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+]
+`;
+
+exports[`prompts (isCI = true) > taskLog > retainLog > error > retainLog = false outputs limited log with limit 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2m│[22m  [2mline 0[22m
+",
+  "[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[31m■[39m  woo!
+",
+  "[2m│[22m
+[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+]
+`;
+
+exports[`prompts (isCI = true) > taskLog > retainLog > error > retainLog = true outputs full log 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2m│[22m  [2mline 0[22m
+",
+  "[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[31m■[39m  woo!
+",
+  "[2m│[22m
+[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+]
+`;
+
+exports[`prompts (isCI = true) > taskLog > retainLog > error > retainLog = true outputs full log with limit 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2m│[22m  [2mline 0[22m
+",
+  "[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[31m■[39m  woo!
+",
+  "[2m│[22m
+[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+]
+`;
+
+exports[`prompts (isCI = true) > taskLog > retainLog > success > outputs limited log with limit by default 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2m│[22m  [2mline 0[22m
+",
+  "[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[32m◆[39m  woo!
+",
+  "[2m│[22m
+[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+]
+`;
+
+exports[`prompts (isCI = true) > taskLog > retainLog > success > retainLog = false outputs full log without limit 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2m│[22m  [2mline 0[22m
+",
+  "[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[32m◆[39m  woo!
+",
+  "[2m│[22m
+[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+]
+`;
+
+exports[`prompts (isCI = true) > taskLog > retainLog > success > retainLog = false outputs limited log with limit 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2m│[22m  [2mline 0[22m
+",
+  "[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[32m◆[39m  woo!
+",
+  "[2m│[22m
+[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+]
+`;
+
+exports[`prompts (isCI = true) > taskLog > retainLog > success > retainLog = true outputs full log 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2m│[22m  [2mline 0[22m
+",
+  "[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[32m◆[39m  woo!
+",
+  "[2m│[22m
+[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+]
+`;
+
+exports[`prompts (isCI = true) > taskLog > retainLog > success > retainLog = true outputs full log with limit 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2m│[22m  [2mline 0[22m
+",
+  "[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+",
+  "[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[32m◆[39m  woo!
+",
+  "[2m│[22m
+[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
+[2m│[22m  [2mline 3[22m
+",
+]
+`;
+
 exports[`prompts (isCI = true) > taskLog > success > clears output and renders message 1`] = `
 [
   "[2m│[22m
@@ -3647,6 +4422,31 @@ exports[`prompts (isCI = true) > taskLog > success > clears output and renders m
   "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
   "[2m│[22m
 [32m◆[39m  success!
+",
+]
+`;
+
+exports[`prompts (isCI = true) > taskLog > success > renders output if renderLog = true 1`] = `
+[
+  "[2m│[22m
+",
+  "[32m◇[39m  foo
+",
+  "[2m│[22m
+",
+  "[2m│[22m  [2mline 0[22m
+",
+  "[2K[1A[2K[G",
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m
+[32m◆[39m  success!
+",
+  "[2m│[22m
+[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
 ",
 ]
 `;

--- a/packages/prompts/src/__snapshots__/index.test.ts.snap
+++ b/packages/prompts/src/__snapshots__/index.test.ts.snap
@@ -1536,21 +1536,18 @@ exports[`prompts (isCI = false) > taskLog > error > maintains output but replace
   "[2m│[22m
 ",
   "[2m│[22m  line 0
-[2m│[22m
 ",
-  "[2K[1A[2K[1A[2K[G",
+  "[2K[1A[2K[G",
   "[2m│[22m  line 0
 [2m│[22m  line 1
-[2m│[22m
 ",
-  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
   "[2m│[22m
 [31m■[39m  some error!
 ",
   "[2m│[22m
 [2m│[22m  line 0
 [2m│[22m  line 1
-[2m│[22m
 ",
 ]
 `;
@@ -1564,12 +1561,10 @@ exports[`prompts (isCI = false) > taskLog > message > can write line by line 1`]
   "[2m│[22m
 ",
   "[2m│[22m  line 0
-[2m│[22m
 ",
-  "[2K[1A[2K[1A[2K[G",
+  "[2K[1A[2K[G",
   "[2m│[22m  line 0
 [2m│[22m  line 1
-[2m│[22m
 ",
 ]
 `;
@@ -1584,7 +1579,6 @@ exports[`prompts (isCI = false) > taskLog > message > can write multiple lines 1
 ",
   "[2m│[22m  line 0
 [2m│[22m  line 1
-[2m│[22m
 ",
 ]
 `;
@@ -1598,17 +1592,14 @@ exports[`prompts (isCI = false) > taskLog > message > enforces limit if set 1`] 
   "[2m│[22m
 ",
   "[2m│[22m  line 0
-[2m│[22m
 ",
-  "[2K[1A[2K[1A[2K[G",
+  "[2K[1A[2K[G",
   "[2m│[22m  line 0
 [2m│[22m  line 1
-[2m│[22m
 ",
-  "[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2K[1A[2K[1A[2K[G",
   "[2m│[22m  line 1
 [2m│[22m  line 2
-[2m│[22m
 ",
 ]
 `;
@@ -1621,26 +1612,18 @@ exports[`prompts (isCI = false) > taskLog > message > handles empty lines 1`] = 
 ",
   "[2m│[22m
 ",
-  "[2m│[22m
+  "
+",
+  "[2m│[22m  line 1
+",
+  "[2K[1A[2K[G",
+  "[2m│[22m  line 1
 [2m│[22m
 ",
   "[2K[1A[2K[1A[2K[G",
-  "[2m│[22m
-[2m│[22m  line 1
-[2m│[22m
-",
-  "[2K[1A[2K[1A[2K[1A[2K[G",
-  "[2m│[22m
-[2m│[22m  line 1
-[2m│[22m
-[2m│[22m
-",
-  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
-  "[2m│[22m
-[2m│[22m  line 1
+  "[2m│[22m  line 1
 [2m│[22m
 [2m│[22m  line 3
-[2m│[22m
 ",
 ]
 `;
@@ -1654,16 +1637,13 @@ exports[`prompts (isCI = false) > taskLog > message > raw = true appends message
   "[2m│[22m
 ",
   "[2m│[22m  line 0
-[2m│[22m
 ",
-  "[2K[1A[2K[1A[2K[G",
+  "[2K[1A[2K[G",
   "[2m│[22m  line 0still line 0
-[2m│[22m
 ",
-  "[2K[1A[2K[1A[2K[G",
+  "[2K[1A[2K[G",
   "[2m│[22m  line 0still line 0
 [2m│[22m  line 1
-[2m│[22m
 ",
 ]
 `;
@@ -1677,16 +1657,13 @@ exports[`prompts (isCI = false) > taskLog > message > raw = true works when mixe
   "[2m│[22m
 ",
   "[2m│[22m  line 0
-[2m│[22m
 ",
-  "[2K[1A[2K[1A[2K[G",
+  "[2K[1A[2K[G",
   "[2m│[22m  line 0still line 0
-[2m│[22m
 ",
-  "[2K[1A[2K[1A[2K[G",
+  "[2K[1A[2K[G",
   "[2m│[22m  line 0still line 0
 [2m│[22m  line 1
-[2m│[22m
 ",
 ]
 `;
@@ -1700,17 +1677,14 @@ exports[`prompts (isCI = false) > taskLog > message > raw = true works when star
   "[2m│[22m
 ",
   "[2m│[22m  line 0
-[2m│[22m
+",
+  "[2K[1A[2K[G",
+  "[2m│[22m  line 0
+[2m│[22m  line 1
 ",
   "[2K[1A[2K[1A[2K[G",
   "[2m│[22m  line 0
-[2m│[22m  line 1
-[2m│[22m
-",
-  "[2K[1A[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  line 0
 [2m│[22m  line 1still line 1
-[2m│[22m
 ",
 ]
 `;
@@ -1724,14 +1698,12 @@ exports[`prompts (isCI = false) > taskLog > success > clears output and renders 
   "[2m│[22m
 ",
   "[2m│[22m  line 0
-[2m│[22m
 ",
-  "[2K[1A[2K[1A[2K[G",
+  "[2K[1A[2K[G",
   "[2m│[22m  line 0
 [2m│[22m  line 1
-[2m│[22m
 ",
-  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
   "[2m│[22m
 [32m◆[39m  success!
 ",
@@ -3497,21 +3469,18 @@ exports[`prompts (isCI = true) > taskLog > error > maintains output but replaces
   "[2m│[22m
 ",
   "[2m│[22m  line 0
-[2m│[22m
 ",
-  "[2K[1A[2K[1A[2K[G",
+  "[2K[1A[2K[G",
   "[2m│[22m  line 0
 [2m│[22m  line 1
-[2m│[22m
 ",
-  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
   "[2m│[22m
 [31m■[39m  some error!
 ",
   "[2m│[22m
 [2m│[22m  line 0
 [2m│[22m  line 1
-[2m│[22m
 ",
 ]
 `;
@@ -3525,12 +3494,10 @@ exports[`prompts (isCI = true) > taskLog > message > can write line by line 1`] 
   "[2m│[22m
 ",
   "[2m│[22m  line 0
-[2m│[22m
 ",
-  "[2K[1A[2K[1A[2K[G",
+  "[2K[1A[2K[G",
   "[2m│[22m  line 0
 [2m│[22m  line 1
-[2m│[22m
 ",
 ]
 `;
@@ -3545,7 +3512,6 @@ exports[`prompts (isCI = true) > taskLog > message > can write multiple lines 1`
 ",
   "[2m│[22m  line 0
 [2m│[22m  line 1
-[2m│[22m
 ",
 ]
 `;
@@ -3559,17 +3525,14 @@ exports[`prompts (isCI = true) > taskLog > message > enforces limit if set 1`] =
   "[2m│[22m
 ",
   "[2m│[22m  line 0
-[2m│[22m
 ",
-  "[2K[1A[2K[1A[2K[G",
+  "[2K[1A[2K[G",
   "[2m│[22m  line 0
 [2m│[22m  line 1
-[2m│[22m
 ",
-  "[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2K[1A[2K[1A[2K[G",
   "[2m│[22m  line 1
 [2m│[22m  line 2
-[2m│[22m
 ",
 ]
 `;
@@ -3582,26 +3545,18 @@ exports[`prompts (isCI = true) > taskLog > message > handles empty lines 1`] = `
 ",
   "[2m│[22m
 ",
-  "[2m│[22m
+  "
+",
+  "[2m│[22m  line 1
+",
+  "[2K[1A[2K[G",
+  "[2m│[22m  line 1
 [2m│[22m
 ",
   "[2K[1A[2K[1A[2K[G",
-  "[2m│[22m
-[2m│[22m  line 1
-[2m│[22m
-",
-  "[2K[1A[2K[1A[2K[1A[2K[G",
-  "[2m│[22m
-[2m│[22m  line 1
-[2m│[22m
-[2m│[22m
-",
-  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
-  "[2m│[22m
-[2m│[22m  line 1
+  "[2m│[22m  line 1
 [2m│[22m
 [2m│[22m  line 3
-[2m│[22m
 ",
 ]
 `;
@@ -3615,16 +3570,13 @@ exports[`prompts (isCI = true) > taskLog > message > raw = true appends message 
   "[2m│[22m
 ",
   "[2m│[22m  line 0
-[2m│[22m
 ",
-  "[2K[1A[2K[1A[2K[G",
+  "[2K[1A[2K[G",
   "[2m│[22m  line 0still line 0
-[2m│[22m
 ",
-  "[2K[1A[2K[1A[2K[G",
+  "[2K[1A[2K[G",
   "[2m│[22m  line 0still line 0
 [2m│[22m  line 1
-[2m│[22m
 ",
 ]
 `;
@@ -3638,16 +3590,13 @@ exports[`prompts (isCI = true) > taskLog > message > raw = true works when mixed
   "[2m│[22m
 ",
   "[2m│[22m  line 0
-[2m│[22m
 ",
-  "[2K[1A[2K[1A[2K[G",
+  "[2K[1A[2K[G",
   "[2m│[22m  line 0still line 0
-[2m│[22m
 ",
-  "[2K[1A[2K[1A[2K[G",
+  "[2K[1A[2K[G",
   "[2m│[22m  line 0still line 0
 [2m│[22m  line 1
-[2m│[22m
 ",
 ]
 `;
@@ -3661,17 +3610,14 @@ exports[`prompts (isCI = true) > taskLog > message > raw = true works when start
   "[2m│[22m
 ",
   "[2m│[22m  line 0
-[2m│[22m
+",
+  "[2K[1A[2K[G",
+  "[2m│[22m  line 0
+[2m│[22m  line 1
 ",
   "[2K[1A[2K[1A[2K[G",
   "[2m│[22m  line 0
-[2m│[22m  line 1
-[2m│[22m
-",
-  "[2K[1A[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  line 0
 [2m│[22m  line 1still line 1
-[2m│[22m
 ",
 ]
 `;
@@ -3685,14 +3631,12 @@ exports[`prompts (isCI = true) > taskLog > success > clears output and renders m
   "[2m│[22m
 ",
   "[2m│[22m  line 0
-[2m│[22m
 ",
-  "[2K[1A[2K[1A[2K[G",
+  "[2K[1A[2K[G",
   "[2m│[22m  line 0
 [2m│[22m  line 1
-[2m│[22m
 ",
-  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
   "[2m│[22m
 [32m◆[39m  success!
 ",

--- a/packages/prompts/src/__snapshots__/index.test.ts.snap
+++ b/packages/prompts/src/__snapshots__/index.test.ts.snap
@@ -1535,19 +1535,19 @@ exports[`prompts (isCI = false) > taskLog > error > maintains output but replace
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  line 0
+  "[2m│[22m  [2mline 0[22m
 ",
   "[2K[1A[2K[G",
-  "[2m│[22m  line 0
-[2m│[22m  line 1
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
 ",
   "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
   "[2m│[22m
 [31m■[39m  some error!
 ",
   "[2m│[22m
-[2m│[22m  line 0
-[2m│[22m  line 1
+[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
 ",
 ]
 `;
@@ -1560,11 +1560,11 @@ exports[`prompts (isCI = false) > taskLog > message > can write line by line 1`]
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  line 0
+  "[2m│[22m  [2mline 0[22m
 ",
   "[2K[1A[2K[G",
-  "[2m│[22m  line 0
-[2m│[22m  line 1
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
 ",
 ]
 `;
@@ -1577,8 +1577,8 @@ exports[`prompts (isCI = false) > taskLog > message > can write multiple lines 1
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  line 0
-[2m│[22m  line 1
+  "[2m│[22m  [2mline 0
+[2m│[22m  line 1[22m
 ",
 ]
 `;
@@ -1591,15 +1591,15 @@ exports[`prompts (isCI = false) > taskLog > message > enforces limit if set 1`] 
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  line 0
+  "[2m│[22m  [2mline 0[22m
 ",
   "[2K[1A[2K[G",
-  "[2m│[22m  line 0
-[2m│[22m  line 1
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
 ",
   "[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  line 1
-[2m│[22m  line 2
+  "[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
 ",
 ]
 `;
@@ -1612,18 +1612,22 @@ exports[`prompts (isCI = false) > taskLog > message > handles empty lines 1`] = 
 ",
   "[2m│[22m
 ",
-  "
-",
-  "[2m│[22m  line 1
+  "[2m│[22m  [2m[22m
 ",
   "[2K[1A[2K[G",
-  "[2m│[22m  line 1
-[2m│[22m
+  "[2m│[22m  [2m[22m
+[2m│[22m  [2mline 1[22m
 ",
   "[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  line 1
-[2m│[22m
-[2m│[22m  line 3
+  "[2m│[22m  [2m[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2m[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2m[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2m[22m
+[2m│[22m  [2mline 3[22m
 ",
 ]
 `;
@@ -1636,14 +1640,14 @@ exports[`prompts (isCI = false) > taskLog > message > raw = true appends message
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  line 0
+  "[2m│[22m  [2mline 0[22m
 ",
   "[2K[1A[2K[G",
-  "[2m│[22m  line 0still line 0
+  "[2m│[22m  [2mline 0[22m[2mstill line 0[22m
 ",
   "[2K[1A[2K[G",
-  "[2m│[22m  line 0still line 0
-[2m│[22m  line 1
+  "[2m│[22m  [2mline 0[22m[2mstill line 0[22m[2m
+[2m│[22m  line 1[22m
 ",
 ]
 `;
@@ -1656,14 +1660,14 @@ exports[`prompts (isCI = false) > taskLog > message > raw = true works when mixe
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  line 0
+  "[2m│[22m  [2mline 0[22m
 ",
   "[2K[1A[2K[G",
-  "[2m│[22m  line 0still line 0
+  "[2m│[22m  [2mline 0[22m[2mstill line 0[22m
 ",
   "[2K[1A[2K[G",
-  "[2m│[22m  line 0still line 0
-[2m│[22m  line 1
+  "[2m│[22m  [2mline 0[22m[2mstill line 0[22m
+[2m│[22m  [2mline 1[22m
 ",
 ]
 `;
@@ -1676,15 +1680,15 @@ exports[`prompts (isCI = false) > taskLog > message > raw = true works when star
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  line 0
+  "[2m│[22m  [2mline 0[22m
 ",
   "[2K[1A[2K[G",
-  "[2m│[22m  line 0
-[2m│[22m  line 1
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
 ",
   "[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  line 0
-[2m│[22m  line 1still line 1
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m[2mstill line 1[22m
 ",
 ]
 `;
@@ -1697,11 +1701,11 @@ exports[`prompts (isCI = false) > taskLog > success > clears output and renders 
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  line 0
+  "[2m│[22m  [2mline 0[22m
 ",
   "[2K[1A[2K[G",
-  "[2m│[22m  line 0
-[2m│[22m  line 1
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
 ",
   "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
   "[2m│[22m
@@ -3468,19 +3472,19 @@ exports[`prompts (isCI = true) > taskLog > error > maintains output but replaces
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  line 0
+  "[2m│[22m  [2mline 0[22m
 ",
   "[2K[1A[2K[G",
-  "[2m│[22m  line 0
-[2m│[22m  line 1
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
 ",
   "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
   "[2m│[22m
 [31m■[39m  some error!
 ",
   "[2m│[22m
-[2m│[22m  line 0
-[2m│[22m  line 1
+[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
 ",
 ]
 `;
@@ -3493,11 +3497,11 @@ exports[`prompts (isCI = true) > taskLog > message > can write line by line 1`] 
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  line 0
+  "[2m│[22m  [2mline 0[22m
 ",
   "[2K[1A[2K[G",
-  "[2m│[22m  line 0
-[2m│[22m  line 1
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
 ",
 ]
 `;
@@ -3510,8 +3514,8 @@ exports[`prompts (isCI = true) > taskLog > message > can write multiple lines 1`
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  line 0
-[2m│[22m  line 1
+  "[2m│[22m  [2mline 0
+[2m│[22m  line 1[22m
 ",
 ]
 `;
@@ -3524,15 +3528,15 @@ exports[`prompts (isCI = true) > taskLog > message > enforces limit if set 1`] =
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  line 0
+  "[2m│[22m  [2mline 0[22m
 ",
   "[2K[1A[2K[G",
-  "[2m│[22m  line 0
-[2m│[22m  line 1
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
 ",
   "[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  line 1
-[2m│[22m  line 2
+  "[2m│[22m  [2mline 1[22m
+[2m│[22m  [2mline 2[22m
 ",
 ]
 `;
@@ -3545,18 +3549,22 @@ exports[`prompts (isCI = true) > taskLog > message > handles empty lines 1`] = `
 ",
   "[2m│[22m
 ",
-  "
-",
-  "[2m│[22m  line 1
+  "[2m│[22m  [2m[22m
 ",
   "[2K[1A[2K[G",
-  "[2m│[22m  line 1
-[2m│[22m
+  "[2m│[22m  [2m[22m
+[2m│[22m  [2mline 1[22m
 ",
   "[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  line 1
-[2m│[22m
-[2m│[22m  line 3
+  "[2m│[22m  [2m[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2m[22m
+",
+  "[2K[1A[2K[1A[2K[1A[2K[G",
+  "[2m│[22m  [2m[22m
+[2m│[22m  [2mline 1[22m
+[2m│[22m  [2m[22m
+[2m│[22m  [2mline 3[22m
 ",
 ]
 `;
@@ -3569,14 +3577,14 @@ exports[`prompts (isCI = true) > taskLog > message > raw = true appends message 
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  line 0
+  "[2m│[22m  [2mline 0[22m
 ",
   "[2K[1A[2K[G",
-  "[2m│[22m  line 0still line 0
+  "[2m│[22m  [2mline 0[22m[2mstill line 0[22m
 ",
   "[2K[1A[2K[G",
-  "[2m│[22m  line 0still line 0
-[2m│[22m  line 1
+  "[2m│[22m  [2mline 0[22m[2mstill line 0[22m[2m
+[2m│[22m  line 1[22m
 ",
 ]
 `;
@@ -3589,14 +3597,14 @@ exports[`prompts (isCI = true) > taskLog > message > raw = true works when mixed
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  line 0
+  "[2m│[22m  [2mline 0[22m
 ",
   "[2K[1A[2K[G",
-  "[2m│[22m  line 0still line 0
+  "[2m│[22m  [2mline 0[22m[2mstill line 0[22m
 ",
   "[2K[1A[2K[G",
-  "[2m│[22m  line 0still line 0
-[2m│[22m  line 1
+  "[2m│[22m  [2mline 0[22m[2mstill line 0[22m
+[2m│[22m  [2mline 1[22m
 ",
 ]
 `;
@@ -3609,15 +3617,15 @@ exports[`prompts (isCI = true) > taskLog > message > raw = true works when start
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  line 0
+  "[2m│[22m  [2mline 0[22m
 ",
   "[2K[1A[2K[G",
-  "[2m│[22m  line 0
-[2m│[22m  line 1
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
 ",
   "[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  line 0
-[2m│[22m  line 1still line 1
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m[2mstill line 1[22m
 ",
 ]
 `;
@@ -3630,11 +3638,11 @@ exports[`prompts (isCI = true) > taskLog > success > clears output and renders m
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  line 0
+  "[2m│[22m  [2mline 0[22m
 ",
   "[2K[1A[2K[G",
-  "[2m│[22m  line 0
-[2m│[22m  line 1
+  "[2m│[22m  [2mline 0[22m
+[2m│[22m  [2mline 1[22m
 ",
   "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
   "[2m│[22m

--- a/packages/prompts/src/__snapshots__/index.test.ts.snap
+++ b/packages/prompts/src/__snapshots__/index.test.ts.snap
@@ -3868,12 +3868,7 @@ exports[`prompts (isCI = true) > taskLog > error > clears output if showLog = fa
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  [2mline 0[22m
-",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m
-[2m│[22m  [2mline 1[22m
-",
   "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
   "[2m│[22m
 [31m■[39m  some error!
@@ -3889,12 +3884,7 @@ exports[`prompts (isCI = true) > taskLog > error > renders output with message 1
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  [2mline 0[22m
-",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m
-[2m│[22m  [2mline 1[22m
-",
   "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
   "[2m│[22m
 [31m■[39m  some error!
@@ -3914,12 +3904,7 @@ exports[`prompts (isCI = true) > taskLog > message > can write line by line 1`] 
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  [2mline 0[22m
-",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m
-[2m│[22m  [2mline 1[22m
-",
 ]
 `;
 
@@ -3930,9 +3915,6 @@ exports[`prompts (isCI = true) > taskLog > message > can write multiple lines 1`
   "[32m◇[39m  foo
 ",
   "[2m│[22m
-",
-  "[2m│[22m  [2mline 0[22m
-[2m│[22m  [2mline 1[22m
 ",
 ]
 `;
@@ -3945,16 +3927,8 @@ exports[`prompts (isCI = true) > taskLog > message > enforces limit if set 1`] =
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  [2mline 0[22m
-",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m
-[2m│[22m  [2mline 1[22m
-",
   "[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  [2mline 1[22m
-[2m│[22m  [2mline 2[22m
-",
 ]
 `;
 
@@ -3966,19 +3940,8 @@ exports[`prompts (isCI = true) > taskLog > message > prints empty lines 1`] = `
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  [2m[22m
-",
-  "[2m│[22m  [2mline 1[22m
-",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 1[22m
-[2m│[22m  [2m[22m
-",
   "[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  [2mline 1[22m
-[2m│[22m  [2m[22m
-[2m│[22m  [2mline 3[22m
-",
 ]
 `;
 
@@ -3990,15 +3953,8 @@ exports[`prompts (isCI = true) > taskLog > message > raw = true appends message 
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  [2mline 0[22m
-",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0still line 0[22m
-",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0still line 0[22m
-[2m│[22m  [2mline 1[22m
-",
 ]
 `;
 
@@ -4010,15 +3966,8 @@ exports[`prompts (isCI = true) > taskLog > message > raw = true works when mixed
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  [2mline 0[22m
-",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0still line 0[22m
-",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0still line 0[22m
-[2m│[22m  [2mline 1[22m
-",
 ]
 `;
 
@@ -4030,16 +3979,8 @@ exports[`prompts (isCI = true) > taskLog > message > raw = true works when start
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  [2mline 0[22m
-",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m
-[2m│[22m  [2mline 1[22m
-",
   "[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m
-[2m│[22m  [2mline 1still line 1[22m
-",
 ]
 `;
 
@@ -4051,20 +3992,9 @@ exports[`prompts (isCI = true) > taskLog > retainLog > error > outputs limited l
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  [2mline 0[22m
-",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m
-[2m│[22m  [2mline 1[22m
-",
   "[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  [2mline 1[22m
-[2m│[22m  [2mline 2[22m
-",
   "[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  [2mline 2[22m
-[2m│[22m  [2mline 3[22m
-",
   "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
   "[2m│[22m
 [31m■[39m  woo!
@@ -4084,23 +4014,9 @@ exports[`prompts (isCI = true) > taskLog > retainLog > error > retainLog = false
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  [2mline 0[22m
-",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m
-[2m│[22m  [2mline 1[22m
-",
   "[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m
-[2m│[22m  [2mline 1[22m
-[2m│[22m  [2mline 2[22m
-",
   "[2K[1A[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m
-[2m│[22m  [2mline 1[22m
-[2m│[22m  [2mline 2[22m
-[2m│[22m  [2mline 3[22m
-",
   "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
   "[2m│[22m
 [31m■[39m  woo!
@@ -4122,20 +4038,9 @@ exports[`prompts (isCI = true) > taskLog > retainLog > error > retainLog = false
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  [2mline 0[22m
-",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m
-[2m│[22m  [2mline 1[22m
-",
   "[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  [2mline 1[22m
-[2m│[22m  [2mline 2[22m
-",
   "[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  [2mline 2[22m
-[2m│[22m  [2mline 3[22m
-",
   "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
   "[2m│[22m
 [31m■[39m  woo!
@@ -4155,23 +4060,9 @@ exports[`prompts (isCI = true) > taskLog > retainLog > error > retainLog = true 
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  [2mline 0[22m
-",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m
-[2m│[22m  [2mline 1[22m
-",
   "[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m
-[2m│[22m  [2mline 1[22m
-[2m│[22m  [2mline 2[22m
-",
   "[2K[1A[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m
-[2m│[22m  [2mline 1[22m
-[2m│[22m  [2mline 2[22m
-[2m│[22m  [2mline 3[22m
-",
   "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
   "[2m│[22m
 [31m■[39m  woo!
@@ -4193,20 +4084,9 @@ exports[`prompts (isCI = true) > taskLog > retainLog > error > retainLog = true 
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  [2mline 0[22m
-",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m
-[2m│[22m  [2mline 1[22m
-",
   "[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  [2mline 1[22m
-[2m│[22m  [2mline 2[22m
-",
   "[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  [2mline 2[22m
-[2m│[22m  [2mline 3[22m
-",
   "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
   "[2m│[22m
 [31m■[39m  woo!
@@ -4228,20 +4108,9 @@ exports[`prompts (isCI = true) > taskLog > retainLog > success > outputs limited
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  [2mline 0[22m
-",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m
-[2m│[22m  [2mline 1[22m
-",
   "[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  [2mline 1[22m
-[2m│[22m  [2mline 2[22m
-",
   "[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  [2mline 2[22m
-[2m│[22m  [2mline 3[22m
-",
   "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
   "[2m│[22m
 [32m◆[39m  woo!
@@ -4261,23 +4130,9 @@ exports[`prompts (isCI = true) > taskLog > retainLog > success > retainLog = fal
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  [2mline 0[22m
-",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m
-[2m│[22m  [2mline 1[22m
-",
   "[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m
-[2m│[22m  [2mline 1[22m
-[2m│[22m  [2mline 2[22m
-",
   "[2K[1A[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m
-[2m│[22m  [2mline 1[22m
-[2m│[22m  [2mline 2[22m
-[2m│[22m  [2mline 3[22m
-",
   "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
   "[2m│[22m
 [32m◆[39m  woo!
@@ -4299,20 +4154,9 @@ exports[`prompts (isCI = true) > taskLog > retainLog > success > retainLog = fal
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  [2mline 0[22m
-",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m
-[2m│[22m  [2mline 1[22m
-",
   "[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  [2mline 1[22m
-[2m│[22m  [2mline 2[22m
-",
   "[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  [2mline 2[22m
-[2m│[22m  [2mline 3[22m
-",
   "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
   "[2m│[22m
 [32m◆[39m  woo!
@@ -4332,23 +4176,9 @@ exports[`prompts (isCI = true) > taskLog > retainLog > success > retainLog = tru
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  [2mline 0[22m
-",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m
-[2m│[22m  [2mline 1[22m
-",
   "[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m
-[2m│[22m  [2mline 1[22m
-[2m│[22m  [2mline 2[22m
-",
   "[2K[1A[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m
-[2m│[22m  [2mline 1[22m
-[2m│[22m  [2mline 2[22m
-[2m│[22m  [2mline 3[22m
-",
   "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
   "[2m│[22m
 [32m◆[39m  woo!
@@ -4370,20 +4200,9 @@ exports[`prompts (isCI = true) > taskLog > retainLog > success > retainLog = tru
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  [2mline 0[22m
-",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m
-[2m│[22m  [2mline 1[22m
-",
   "[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  [2mline 1[22m
-[2m│[22m  [2mline 2[22m
-",
   "[2K[1A[2K[1A[2K[G",
-  "[2m│[22m  [2mline 2[22m
-[2m│[22m  [2mline 3[22m
-",
   "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
   "[2m│[22m
 [32m◆[39m  woo!
@@ -4405,12 +4224,7 @@ exports[`prompts (isCI = true) > taskLog > success > clears output and renders m
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  [2mline 0[22m
-",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m
-[2m│[22m  [2mline 1[22m
-",
   "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
   "[2m│[22m
 [32m◆[39m  success!
@@ -4426,12 +4240,7 @@ exports[`prompts (isCI = true) > taskLog > success > renders output if showLog =
 ",
   "[2m│[22m
 ",
-  "[2m│[22m  [2mline 0[22m
-",
   "[2K[1A[2K[G",
-  "[2m│[22m  [2mline 0[22m
-[2m│[22m  [2mline 1[22m
-",
   "[2K[1A[2K[1A[2K[1A[2K[1A[2K[1A[2K[G",
   "[2m│[22m
 [32m◆[39m  success!

--- a/packages/prompts/src/index.test.ts
+++ b/packages/prompts/src/index.test.ts
@@ -1233,6 +1233,48 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 
 				expect(output.buffer).toMatchSnapshot();
 			});
+
+			test('raw = true appends message text until newline', async () => {
+				const log = prompts.taskLog({
+					input,
+					output,
+					message: 'foo',
+				});
+
+				log.message('line 0', { raw: true });
+				log.message('still line 0', { raw: true });
+				log.message('\nline 1', { raw: true });
+
+				expect(output.buffer).toMatchSnapshot();
+			});
+
+			test('raw = true works when mixed with non-raw messages', async () => {
+				const log = prompts.taskLog({
+					input,
+					output,
+					message: 'foo',
+				});
+
+				log.message('line 0', { raw: true });
+				log.message('still line 0', { raw: true });
+				log.message('line 1');
+
+				expect(output.buffer).toMatchSnapshot();
+			});
+
+			test('raw = true works when started with non-raw messages', async () => {
+				const log = prompts.taskLog({
+					input,
+					output,
+					message: 'foo',
+				});
+
+				log.message('line 0');
+				log.message('line 1', { raw: true });
+				log.message('still line 1', { raw: true });
+
+				expect(output.buffer).toMatchSnapshot();
+			});
 		});
 
 		describe('error', () => {

--- a/packages/prompts/src/index.test.ts
+++ b/packages/prompts/src/index.test.ts
@@ -1293,7 +1293,7 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 		});
 
 		describe('error', () => {
-			test('maintains output but replaces message', () => {
+			test('renders output with message', () => {
 				const log = prompts.taskLog({
 					input,
 					output,
@@ -1304,6 +1304,21 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 				log.message('line 1');
 
 				log.error('some error!');
+
+				expect(output.buffer).toMatchSnapshot();
+			});
+
+			test('clears output if renderLog = false', () => {
+				const log = prompts.taskLog({
+					input,
+					output,
+					title: 'foo',
+				});
+
+				log.message('line 0');
+				log.message('line 1');
+
+				log.error('some error!', { renderLog: false });
 
 				expect(output.buffer).toMatchSnapshot();
 			});
@@ -1323,6 +1338,112 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 				log.success('success!');
 
 				expect(output.buffer).toMatchSnapshot();
+			});
+
+			test('renders output if renderLog = true', () => {
+				const log = prompts.taskLog({
+					input,
+					output,
+					title: 'foo',
+				});
+
+				log.message('line 0');
+				log.message('line 1');
+
+				log.success('success!', { renderLog: true });
+
+				expect(output.buffer).toMatchSnapshot();
+			});
+		});
+
+		describe('retainLog', () => {
+			describe.each(['error', 'success'] as const)('%s', (method) => {
+				test('retainLog = true outputs full log', () => {
+					const log = prompts.taskLog({
+						input,
+						output,
+						title: 'foo',
+						retainLog: true,
+					});
+
+					for (let i = 0; i < 4; i++) {
+						log.message(`line ${i}`);
+					}
+
+					log[method]('woo!', { renderLog: true });
+
+					expect(output.buffer).toMatchSnapshot();
+				});
+
+				test('retainLog = true outputs full log with limit', () => {
+					const log = prompts.taskLog({
+						input,
+						output,
+						title: 'foo',
+						retainLog: true,
+						limit: 2,
+					});
+
+					for (let i = 0; i < 4; i++) {
+						log.message(`line ${i}`);
+					}
+
+					log[method]('woo!', { renderLog: true });
+
+					expect(output.buffer).toMatchSnapshot();
+				});
+
+				test('retainLog = false outputs full log without limit', () => {
+					const log = prompts.taskLog({
+						input,
+						output,
+						title: 'foo',
+						retainLog: false,
+					});
+
+					for (let i = 0; i < 4; i++) {
+						log.message(`line ${i}`);
+					}
+
+					log[method]('woo!', { renderLog: true });
+
+					expect(output.buffer).toMatchSnapshot();
+				});
+
+				test('retainLog = false outputs limited log with limit', () => {
+					const log = prompts.taskLog({
+						input,
+						output,
+						title: 'foo',
+						retainLog: false,
+						limit: 2,
+					});
+
+					for (let i = 0; i < 4; i++) {
+						log.message(`line ${i}`);
+					}
+
+					log[method]('woo!', { renderLog: true });
+
+					expect(output.buffer).toMatchSnapshot();
+				});
+
+				test('outputs limited log with limit by default', () => {
+					const log = prompts.taskLog({
+						input,
+						output,
+						title: 'foo',
+						limit: 2,
+					});
+
+					for (let i = 0; i < 4; i++) {
+						log.message(`line ${i}`);
+					}
+
+					log[method]('woo!', { renderLog: true });
+
+					expect(output.buffer).toMatchSnapshot();
+				});
 			});
 		});
 	});

--- a/packages/prompts/src/index.test.ts
+++ b/packages/prompts/src/index.test.ts
@@ -1276,7 +1276,7 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 				expect(output.buffer).toMatchSnapshot();
 			});
 
-			test('handles empty lines', async () => {
+			test('prints empty lines', async () => {
 				const log = prompts.taskLog({
 					input,
 					output,

--- a/packages/prompts/src/index.test.ts
+++ b/packages/prompts/src/index.test.ts
@@ -1308,7 +1308,7 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 				expect(output.buffer).toMatchSnapshot();
 			});
 
-			test('clears output if renderLog = false', () => {
+			test('clears output if showLog = false', () => {
 				const log = prompts.taskLog({
 					input,
 					output,
@@ -1318,7 +1318,7 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 				log.message('line 0');
 				log.message('line 1');
 
-				log.error('some error!', { renderLog: false });
+				log.error('some error!', { showLog: false });
 
 				expect(output.buffer).toMatchSnapshot();
 			});
@@ -1340,7 +1340,7 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 				expect(output.buffer).toMatchSnapshot();
 			});
 
-			test('renders output if renderLog = true', () => {
+			test('renders output if showLog = true', () => {
 				const log = prompts.taskLog({
 					input,
 					output,
@@ -1350,7 +1350,7 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 				log.message('line 0');
 				log.message('line 1');
 
-				log.success('success!', { renderLog: true });
+				log.success('success!', { showLog: true });
 
 				expect(output.buffer).toMatchSnapshot();
 			});
@@ -1370,7 +1370,7 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 						log.message(`line ${i}`);
 					}
 
-					log[method]('woo!', { renderLog: true });
+					log[method]('woo!', { showLog: true });
 
 					expect(output.buffer).toMatchSnapshot();
 				});
@@ -1388,7 +1388,7 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 						log.message(`line ${i}`);
 					}
 
-					log[method]('woo!', { renderLog: true });
+					log[method]('woo!', { showLog: true });
 
 					expect(output.buffer).toMatchSnapshot();
 				});
@@ -1405,7 +1405,7 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 						log.message(`line ${i}`);
 					}
 
-					log[method]('woo!', { renderLog: true });
+					log[method]('woo!', { showLog: true });
 
 					expect(output.buffer).toMatchSnapshot();
 				});
@@ -1423,7 +1423,7 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 						log.message(`line ${i}`);
 					}
 
-					log[method]('woo!', { renderLog: true });
+					log[method]('woo!', { showLog: true });
 
 					expect(output.buffer).toMatchSnapshot();
 				});
@@ -1440,7 +1440,7 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 						log.message(`line ${i}`);
 					}
 
-					log[method]('woo!', { renderLog: true });
+					log[method]('woo!', { showLog: true });
 
 					expect(output.buffer).toMatchSnapshot();
 				});

--- a/packages/prompts/src/index.test.ts
+++ b/packages/prompts/src/index.test.ts
@@ -1181,4 +1181,92 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 			expect(output.buffer).toMatchSnapshot();
 		});
 	});
+
+	describe('taskLog', () => {
+		test('writes message header', () => {
+			prompts.taskLog({
+				input,
+				output,
+				message: 'foo',
+			});
+
+			expect(output.buffer).toMatchSnapshot();
+		});
+
+		describe('message', () => {
+			test('can write line by line', () => {
+				const log = prompts.taskLog({
+					input,
+					output,
+					message: 'foo',
+				});
+
+				log.message('line 0');
+				log.message('line 1');
+
+				expect(output.buffer).toMatchSnapshot();
+			});
+
+			test('can write multiple lines', () => {
+				const log = prompts.taskLog({
+					input,
+					output,
+					message: 'foo',
+				});
+
+				log.message('line 0\nline 1');
+
+				expect(output.buffer).toMatchSnapshot();
+			});
+
+			test('enforces limit if set', () => {
+				const log = prompts.taskLog({
+					input,
+					output,
+					message: 'foo',
+					limit: 2,
+				});
+
+				log.message('line 0');
+				log.message('line 1');
+				log.message('line 2');
+
+				expect(output.buffer).toMatchSnapshot();
+			});
+		});
+
+		describe('error', () => {
+			test('maintains output but replaces message', () => {
+				const log = prompts.taskLog({
+					input,
+					output,
+					message: 'foo',
+				});
+
+				log.message('line 0');
+				log.message('line 1');
+
+				log.error('some error!');
+
+				expect(output.buffer).toMatchSnapshot();
+			});
+		});
+
+		describe('success', () => {
+			test('clears output and renders message', () => {
+				const log = prompts.taskLog({
+					input,
+					output,
+					message: 'foo',
+				});
+
+				log.message('line 0');
+				log.message('line 1');
+
+				log.success('success!');
+
+				expect(output.buffer).toMatchSnapshot();
+			});
+		});
+	});
 });

--- a/packages/prompts/src/index.test.ts
+++ b/packages/prompts/src/index.test.ts
@@ -1275,6 +1275,21 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 
 				expect(output.buffer).toMatchSnapshot();
 			});
+
+			test('handles empty lines', async () => {
+				const log = prompts.taskLog({
+					input,
+					output,
+					message: 'foo',
+				});
+
+				log.message('');
+				log.message('line 1');
+				log.message('');
+				log.message('line 3');
+
+				expect(output.buffer).toMatchSnapshot();
+			});
 		});
 
 		describe('error', () => {

--- a/packages/prompts/src/index.test.ts
+++ b/packages/prompts/src/index.test.ts
@@ -1187,7 +1187,7 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 			prompts.taskLog({
 				input,
 				output,
-				message: 'foo',
+				title: 'foo',
 			});
 
 			expect(output.buffer).toMatchSnapshot();
@@ -1198,7 +1198,7 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 				const log = prompts.taskLog({
 					input,
 					output,
-					message: 'foo',
+					title: 'foo',
 				});
 
 				log.message('line 0');
@@ -1211,7 +1211,7 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 				const log = prompts.taskLog({
 					input,
 					output,
-					message: 'foo',
+					title: 'foo',
 				});
 
 				log.message('line 0\nline 1');
@@ -1223,7 +1223,7 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 				const log = prompts.taskLog({
 					input,
 					output,
-					message: 'foo',
+					title: 'foo',
 					limit: 2,
 				});
 
@@ -1238,7 +1238,7 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 				const log = prompts.taskLog({
 					input,
 					output,
-					message: 'foo',
+					title: 'foo',
 				});
 
 				log.message('line 0', { raw: true });
@@ -1252,7 +1252,7 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 				const log = prompts.taskLog({
 					input,
 					output,
-					message: 'foo',
+					title: 'foo',
 				});
 
 				log.message('line 0', { raw: true });
@@ -1266,7 +1266,7 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 				const log = prompts.taskLog({
 					input,
 					output,
-					message: 'foo',
+					title: 'foo',
 				});
 
 				log.message('line 0');
@@ -1280,7 +1280,7 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 				const log = prompts.taskLog({
 					input,
 					output,
-					message: 'foo',
+					title: 'foo',
 				});
 
 				log.message('');
@@ -1297,7 +1297,7 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 				const log = prompts.taskLog({
 					input,
 					output,
-					message: 'foo',
+					title: 'foo',
 				});
 
 				log.message('line 0');
@@ -1314,7 +1314,7 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 				const log = prompts.taskLog({
 					input,
 					output,
-					message: 'foo',
+					title: 'foo',
 				});
 
 				log.message('line 0');

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -1072,12 +1072,12 @@ export const taskLog = (opts: TaskLogOptions) => {
 		message(msg: string, mopts?: TaskLogMessageOptions) {
 			clear(false);
 			if (mopts?.raw && lastMessageWasRaw) {
-				buffer += msg;
+				buffer += color.dim(msg);
 			} else {
 				if (buffer !== '') {
 					buffer += '\n';
 				}
-				buffer += msg;
+				buffer += color.dim(msg);
 			}
 			lastMessageWasRaw = mopts?.raw === true;
 			if (opts.limit !== undefined) {

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -1037,7 +1037,7 @@ export interface TaskLogMessageOptions {
 }
 
 export interface TaskLogCompletionOptions {
-	renderLog?: boolean;
+	showLog?: boolean;
 }
 
 /**
@@ -1117,7 +1117,7 @@ export const taskLog = (opts: TaskLogOptions) => {
 		error(message: string, opts?: TaskLogCompletionOptions): void {
 			clear(true);
 			log.error(message, { output, secondarySymbol, spacing: 1 });
-			if (opts?.renderLog !== false) {
+			if (opts?.showLog !== false) {
 				renderBuffer();
 			}
 			// clear buffer since error is an end state
@@ -1126,7 +1126,7 @@ export const taskLog = (opts: TaskLogOptions) => {
 		success(message: string, opts?: TaskLogCompletionOptions): void {
 			clear(true);
 			log.success(message, { output, secondarySymbol, spacing: 1 });
-			if (opts?.renderLog === true) {
+			if (opts?.showLog === true) {
 				renderBuffer();
 			}
 			// clear buffer since success is an end state

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -1031,11 +1031,11 @@ export const taskLog = (opts: TaskLogOptions) => {
 	output.write(`${color.green(S_STEP_SUBMIT)}  ${opts.message}\n`);
 	output.write(`${color.dim(S_BAR)}\n`);
 
-	const buffer: string[] = [];
+	let buffer = '';
 	let lastMessageWasRaw = false;
 
 	const clear = (clearTitle: boolean): void => {
-		const bufferHeight = buffer.reduce((count, line) => {
+		const bufferHeight = buffer.split('\n').reduce((count, line) => {
 			return count + Math.ceil(line.length / columns);
 		}, 0);
 		const lines = bufferHeight + 1 + (clearTitle ? 2 : 0);
@@ -1045,20 +1045,19 @@ export const taskLog = (opts: TaskLogOptions) => {
 	return {
 		message(msg: string, mopts?: TaskLogMessageOptions) {
 			clear(false);
-			let lines: string[];
-			if (mopts?.raw && buffer.length > 0 && lastMessageWasRaw) {
-				const lastBuffer = buffer.pop();
-				lines = (lastBuffer + msg).split('\n');
+			if (buffer.length === 0 || (mopts?.raw && lastMessageWasRaw)) {
+				buffer += msg;
 			} else {
-				lines = msg.split('\n');
+				buffer += `\n${msg}`;
 			}
 			lastMessageWasRaw = mopts?.raw === true;
-			for (const line of lines) {
-				buffer.push(line);
-			}
-			const linesToRemove = opts.limit !== undefined ? buffer.length - opts.limit : 0;
-			if (linesToRemove > 0) {
-				buffer.splice(0, linesToRemove);
+			if (opts.limit !== undefined) {
+				const lines = buffer.split('\n');
+				const linesToRemove = lines.length - opts.limit;
+				if (linesToRemove > 0) {
+					lines.splice(0, linesToRemove);
+				}
+				buffer = lines.join('\n');
 			}
 			log.message(buffer, { output, spacing: 0 });
 		},

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -1016,6 +1016,10 @@ export interface TaskLogOptions extends CommonOptions {
 	limit?: number;
 }
 
+export interface TaskLogMessageOptions {
+	raw?: boolean;
+}
+
 /**
  * Renders a log which clears on success and remains on failure
  */
@@ -1028,6 +1032,7 @@ export const taskLog = (opts: TaskLogOptions) => {
 	output.write(`${color.dim(S_BAR)}\n`);
 
 	const buffer: string[] = [];
+	let lastMessageWasRaw = false;
 
 	const clear = (clearTitle: boolean): void => {
 		const bufferHeight = buffer.reduce((count, line) => {
@@ -1038,9 +1043,16 @@ export const taskLog = (opts: TaskLogOptions) => {
 	};
 
 	return {
-		message(msg: string) {
+		message(msg: string, mopts?: TaskLogMessageOptions) {
 			clear(false);
-			const lines = msg.split('\n');
+			let lines: string[];
+			if (mopts?.raw && buffer.length > 0 && lastMessageWasRaw) {
+				const lastBuffer = buffer.pop();
+				lines = (lastBuffer + msg).split('\n');
+			} else {
+				lines = msg.split('\n');
+			}
+			lastMessageWasRaw = mopts?.raw === true;
 			for (const line of lines) {
 				buffer.push(line);
 			}

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -1036,6 +1036,9 @@ export const taskLog = (opts: TaskLogOptions) => {
 
 	const clear = (clearTitle: boolean): void => {
 		const bufferHeight = buffer.split('\n').reduce((count, line) => {
+			if (line === '') {
+				return count + 1;
+			}
 			return count + Math.ceil(line.length / columns);
 		}, 0);
 		const lines = bufferHeight + 1 + (clearTitle ? 2 : 0);

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -704,7 +704,7 @@ export const log = {
 			parts.push(`${secondarySymbol}`);
 		}
 		const messageParts = Array.isArray(message) ? message : message.split('\n');
-		if (message && messageParts.length > 0) {
+		if (messageParts.length > 0) {
 			const [firstLine, ...lines] = messageParts;
 			if (firstLine.length > 0) {
 				parts.push(`${symbol}  ${firstLine}`);
@@ -1074,27 +1074,29 @@ export const taskLog = (opts: TaskLogOptions) => {
 		const lines = bufferHeight + 1 + (clearTitle ? spacing + 2 : 0);
 		output.write(erase.lines(lines));
 	};
+	const printBuffer = (buf: string, messageSpacing?: number): void => {
+		log.message(buf.split('\n').map(color.dim), {
+			output,
+			secondarySymbol,
+			symbol: secondarySymbol,
+			spacing: messageSpacing ?? spacing,
+		});
+	};
 	const renderBuffer = (): void => {
 		if (retainLog === true && fullBuffer.length > 0) {
-			log.message(`${fullBuffer}\n${buffer}`, {
-				output,
-				secondarySymbol,
-				symbol: secondarySymbol,
-				spacing,
-			});
+			printBuffer(`${fullBuffer}\n${buffer}`);
 		} else {
-			log.message(buffer, { output, secondarySymbol, symbol: secondarySymbol, spacing });
+			printBuffer(buffer);
 		}
 	};
 
 	return {
 		message(msg: string, mopts?: TaskLogMessageOptions) {
 			clear(false);
-			const dimMessage = color.dim(msg);
 			if ((mopts?.raw !== true || !lastMessageWasRaw) && buffer !== '') {
 				buffer += '\n';
 			}
-			buffer += dimMessage;
+			buffer += msg;
 			lastMessageWasRaw = mopts?.raw === true;
 			if (opts.limit !== undefined) {
 				const lines = buffer.split('\n');
@@ -1107,12 +1109,7 @@ export const taskLog = (opts: TaskLogOptions) => {
 				}
 				buffer = lines.join('\n');
 			}
-			log.message(buffer, {
-				output,
-				secondarySymbol,
-				symbol: secondarySymbol,
-				spacing: 0,
-			});
+			printBuffer(buffer, 0);
 		},
 		error(message: string, opts?: TaskLogCompletionOptions): void {
 			clear(true);

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -1026,7 +1026,7 @@ export const tasks = async (tasks: Task[], opts?: CommonOptions) => {
 };
 
 export interface TaskLogOptions extends CommonOptions {
-	message: string;
+	title: string;
 	limit?: number;
 	spacing?: number;
 }
@@ -1046,7 +1046,7 @@ export const taskLog = (opts: TaskLogOptions) => {
 	const barSize = 3;
 
 	output.write(`${secondarySymbol}\n`);
-	output.write(`${color.green(S_STEP_SUBMIT)}  ${opts.message}\n`);
+	output.write(`${color.green(S_STEP_SUBMIT)}  ${opts.title}\n`);
 	for (let i = 0; i < spacing; i++) {
 		output.write(`${secondarySymbol}\n`);
 	}

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -1050,6 +1050,7 @@ export const taskLog = (opts: TaskLogOptions) => {
 	const spacing = opts.spacing ?? 1;
 	const barSize = 3;
 	const retainLog = opts.retainLog === true;
+	const isCI = process.env.CI === 'true';
 
 	output.write(`${secondarySymbol}\n`);
 	output.write(`${color.green(S_STEP_SUBMIT)}  ${opts.title}\n`);
@@ -1109,7 +1110,9 @@ export const taskLog = (opts: TaskLogOptions) => {
 				}
 				buffer = lines.join('\n');
 			}
-			printBuffer(buffer, 0);
+			if (!isCI) {
+				printBuffer(buffer, 0);
+			}
 		},
 		error(message: string, opts?: TaskLogCompletionOptions): void {
 			clear(true);


### PR DESCRIPTION
Adds a new taskLog prompt which renders messages then ultimately does one of the following:

- If error, retain the output and render the error message
- If success, clear the output and render the success message

For example:

```ts
const log = prompts.taskLog({
  message: 'some message'
});

log.message('a line of text');
log.message('another line of text');
log.message('multiple\nlines\nof\ntext');

// at this point, it will have rendered like so:
// o some message
// | a line of text
// | another line of text
// ...

log.error('some error');

// if the line above runs, it will render like so:
// x some error
// | a line of text
// | another line of text
// ...

log.success('some success');

// if the line above runs, it will clear and render like so:
// o some success
```

part of bringing svelte CLI back to using clack instead of a fork