### PR TITLE
feat: add `format` option to `note` prompt

### DIFF
--- a/.changeset/empty-buses-wonder.md
+++ b/.changeset/empty-buses-wonder.md
@@ -1,0 +1,5 @@
+---
+"@clack/prompts": minor
+---
+
+Added `formatter` option to the note prompt to allow formatting of individual lines

--- a/.changeset/empty-buses-wonder.md
+++ b/.changeset/empty-buses-wonder.md
@@ -2,4 +2,4 @@
 "@clack/prompts": minor
 ---
 
-Added `formatter` option to the note prompt to allow formatting of individual lines
+Adds `format` option to the note prompt to allow formatting of individual lines

--- a/packages/prompts/src/__snapshots__/index.test.ts.snap
+++ b/packages/prompts/src/__snapshots__/index.test.ts.snap
@@ -1265,6 +1265,59 @@ exports[`prompts (isCI = false) > multiselect > sliding window loops upwards 1`]
 ]
 `;
 
+exports[`prompts (isCI = false) > note > formatter which adds colors works 1`] = `
+[
+  "[90m│[39m
+[32m◇[39m  [0mtitle[0m [90m──╮[39m
+[90m│[39m          [90m│[39m
+[90m│[39m  [31mline 0[39m  [90m│[39m
+[90m│[39m  [31mline 1[39m  [90m│[39m
+[90m│[39m  [31mline 2[39m  [90m│[39m
+[90m│[39m          [90m│[39m
+[90m├──────────╯[39m
+",
+]
+`;
+
+exports[`prompts (isCI = false) > note > formatter which adds length works 1`] = `
+[
+  "[90m│[39m
+[32m◇[39m  [0mtitle[0m [90m──────╮[39m
+[90m│[39m              [90m│[39m
+[90m│[39m  * line 0 *  [90m│[39m
+[90m│[39m  * line 1 *  [90m│[39m
+[90m│[39m  * line 2 *  [90m│[39m
+[90m│[39m              [90m│[39m
+[90m├──────────────╯[39m
+",
+]
+`;
+
+exports[`prompts (isCI = false) > note > renders as wide as longest line 1`] = `
+[
+  "[90m│[39m
+[32m◇[39m  [0mtitle[0m [90m───────────────────────────╮[39m
+[90m│[39m                                   [90m│[39m
+[90m│[39m  [2mshort[22m                            [90m│[39m
+[90m│[39m  [2msomewhat questionably long line[22m  [90m│[39m
+[90m│[39m                                   [90m│[39m
+[90m├───────────────────────────────────╯[39m
+",
+]
+`;
+
+exports[`prompts (isCI = false) > note > renders message with title 1`] = `
+[
+  "[90m│[39m
+[32m◇[39m  [0mtitle[0m [90m───╮[39m
+[90m│[39m           [90m│[39m
+[90m│[39m  [2mmessage[22m  [90m│[39m
+[90m│[39m           [90m│[39m
+[90m├───────────╯[39m
+",
+]
+`;
+
 exports[`prompts (isCI = false) > password > renders and clears validation errors 1`] = `
 [
   "[?25l",
@@ -3124,6 +3177,59 @@ exports[`prompts (isCI = true) > multiselect > sliding window loops upwards 1`] 
   "
 ",
   "[?25h",
+]
+`;
+
+exports[`prompts (isCI = true) > note > formatter which adds colors works 1`] = `
+[
+  "[90m│[39m
+[32m◇[39m  [0mtitle[0m [90m──╮[39m
+[90m│[39m          [90m│[39m
+[90m│[39m  [31mline 0[39m  [90m│[39m
+[90m│[39m  [31mline 1[39m  [90m│[39m
+[90m│[39m  [31mline 2[39m  [90m│[39m
+[90m│[39m          [90m│[39m
+[90m├──────────╯[39m
+",
+]
+`;
+
+exports[`prompts (isCI = true) > note > formatter which adds length works 1`] = `
+[
+  "[90m│[39m
+[32m◇[39m  [0mtitle[0m [90m──────╮[39m
+[90m│[39m              [90m│[39m
+[90m│[39m  * line 0 *  [90m│[39m
+[90m│[39m  * line 1 *  [90m│[39m
+[90m│[39m  * line 2 *  [90m│[39m
+[90m│[39m              [90m│[39m
+[90m├──────────────╯[39m
+",
+]
+`;
+
+exports[`prompts (isCI = true) > note > renders as wide as longest line 1`] = `
+[
+  "[90m│[39m
+[32m◇[39m  [0mtitle[0m [90m───────────────────────────╮[39m
+[90m│[39m                                   [90m│[39m
+[90m│[39m  [2mshort[22m                            [90m│[39m
+[90m│[39m  [2msomewhat questionably long line[22m  [90m│[39m
+[90m│[39m                                   [90m│[39m
+[90m├───────────────────────────────────╯[39m
+",
+]
+`;
+
+exports[`prompts (isCI = true) > note > renders message with title 1`] = `
+[
+  "[90m│[39m
+[32m◇[39m  [0mtitle[0m [90m───╮[39m
+[90m│[39m           [90m│[39m
+[90m│[39m  [2mmessage[22m  [90m│[39m
+[90m│[39m           [90m│[39m
+[90m├───────────╯[39m
+",
 ]
 `;
 

--- a/packages/prompts/src/index.test.ts
+++ b/packages/prompts/src/index.test.ts
@@ -1,4 +1,5 @@
 import { Readable, Writable } from 'node:stream';
+import colors from 'picocolors';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as prompts from './index.js';
 
@@ -1247,6 +1248,46 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 
 				expect(output.buffer).toMatchSnapshot();
 			});
+		});
+	});
+
+	describe('note', () => {
+		test('renders message with title', () => {
+			prompts.note('message', 'title', {
+				input,
+				output,
+			});
+
+			expect(output.buffer).toMatchSnapshot();
+		});
+
+		test('renders as wide as longest line', () => {
+			prompts.note('short\nsomewhat questionably long line', 'title', {
+				input,
+				output,
+			});
+
+			expect(output.buffer).toMatchSnapshot();
+		});
+
+		test('formatter which adds length works', () => {
+			prompts.note('line 0\nline 1\nline 2', 'title', {
+				formatter: (line) => `* ${line} *`,
+				input,
+				output,
+			});
+
+			expect(output.buffer).toMatchSnapshot();
+		});
+
+		test('formatter which adds colors works', () => {
+			prompts.note('line 0\nline 1\nline 2', 'title', {
+				formatter: (line) => colors.red(line),
+				input,
+				output,
+			});
+
+			expect(output.buffer).toMatchSnapshot();
 		});
 	});
 });

--- a/packages/prompts/src/index.test.ts
+++ b/packages/prompts/src/index.test.ts
@@ -1272,7 +1272,7 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 
 		test('formatter which adds length works', () => {
 			prompts.note('line 0\nline 1\nline 2', 'title', {
-				formatter: (line) => `* ${line} *`,
+				format: (line) => `* ${line} *`,
 				input,
 				output,
 			});
@@ -1282,7 +1282,7 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 
 		test('formatter which adds colors works', () => {
 			prompts.note('line 0\nline 1\nline 2', 'title', {
-				formatter: (line) => colors.red(line),
+				format: (line) => colors.red(line),
 				input,
 				output,
 			});

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -642,8 +642,15 @@ export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) =>
 	}).prompt() as Promise<Value[] | symbol>;
 };
 
-export const note = (message = '', title = '', opts?: CommonOptions) => {
-	const lines = `\n${message}\n`.split('\n');
+export interface NoteOptions extends CommonOptions {
+	formatter?: (line: string) => string;
+}
+
+const defaultNoteFormatter = (line: string): string => color.dim(line);
+
+export const note = (message = '', title = '', opts?: NoteOptions) => {
+	const formatter = opts?.formatter ?? defaultNoteFormatter;
+	const lines = ['', ...message.split('\n').map(formatter), ''];
 	const titleLen = strip(title).length;
 	const output: Writable = opts?.output ?? process.stdout;
 	const len =
@@ -656,10 +663,7 @@ export const note = (message = '', title = '', opts?: CommonOptions) => {
 		) + 2;
 	const msg = lines
 		.map(
-			(ln) =>
-				`${color.gray(S_BAR)}  ${color.dim(ln)}${' '.repeat(len - strip(ln).length)}${color.gray(
-					S_BAR
-				)}`
+			(ln) => `${color.gray(S_BAR)}  ${ln}${' '.repeat(len - strip(ln).length)}${color.gray(S_BAR)}`
 		)
 		.join('\n');
 	output.write(

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -643,14 +643,14 @@ export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) =>
 };
 
 export interface NoteOptions extends CommonOptions {
-	formatter?: (line: string) => string;
+	format?: (line: string) => string;
 }
 
 const defaultNoteFormatter = (line: string): string => color.dim(line);
 
 export const note = (message = '', title = '', opts?: NoteOptions) => {
-	const formatter = opts?.formatter ?? defaultNoteFormatter;
-	const lines = ['', ...message.split('\n').map(formatter), ''];
+	const format = opts?.format ?? defaultNoteFormatter;
+	const lines = ['', ...message.split('\n').map(format), ''];
 	const titleLen = strip(title).length;
 	const output: Writable = opts?.output ?? process.stdout;
 	const len =


### PR DESCRIPTION
This adds a new `format` option for formatting lines in a note.

For example:

```ts
// make all lines cyan
note('message', 'title', {
  format(str) {
    return colors.cyan(str);
  }
});

// don't colour lines at all
note('message', 'title', {
  format(str) {
    return str;
  }
});

// add extra text to each line
note('message', 'title', {
  format(str) {
    return `more text ${str} more text';
  }
});
```

cc @AdrianGonz97