### PR TITLE
feat(prompts): add autocomplete support for text prompts

### DIFF
--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -109,7 +109,7 @@ export interface CommonOptions {
 
 export interface TextOptions extends CommonOptions {
 	message: string;
-	autocomplete?: string[] | ((input: string) => Promise<string[]>);
+	autocomplete?: string[] | ((input: string) => Promise<string | undefined>);
 	placeholder?: string;
 	defaultValue?: string;
 	initialValue?: string;

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -109,6 +109,7 @@ export interface CommonOptions {
 
 export interface TextOptions extends CommonOptions {
 	message: string;
+	autocomplete?: string[] | ((input: string) => Promise<string[]>);
 	placeholder?: string;
 	defaultValue?: string;
 	initialValue?: string;
@@ -117,6 +118,7 @@ export interface TextOptions extends CommonOptions {
 export const text = (opts: TextOptions) => {
 	return new TextPrompt({
 		validate: opts.validate,
+		autocomplete: opts.autocomplete,
 		placeholder: opts.placeholder,
 		defaultValue: opts.defaultValue,
 		initialValue: opts.initialValue,


### PR DESCRIPTION
This commit introduces autocomplete functionality for text prompts, allowing users to provide a list of suggestions or a function to generate suggestions dynamically. The feature enhances user experience by enabling faster and more accurate input.