### PR TITLE
fix(prompts): don't strip dots in spinner stop

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,9 +10,3 @@ insert_final_newline = true
 [*.yml]
 indent_style = space
 indent_size = 2
-
-[*.snap]
-trim_trailing_whitespace = false
-
-[*.md]
-trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,9 @@ insert_final_newline = true
 [*.yml]
 indent_style = space
 indent_size = 2
+
+[*.snap]
+trim_trailing_whitespace = false
+
+[*.md]
+trim_trailing_whitespace = false

--- a/packages/prompts/src/__snapshots__/index.test.ts.snap
+++ b/packages/prompts/src/__snapshots__/index.test.ts.snap
@@ -1767,6 +1767,20 @@ exports[`prompts (isCI = false) > spinner > stop > renders message 1`] = `
 ]
 `;
 
+exports[`prompts (isCI = false) > spinner > stop > renders message without removing dots 1`] = `
+[
+  "[?25l",
+  "[90m│[39m
+",
+  "[35m◒[39m  ",
+  "[999D",
+  "[J",
+  "[32m◇[39m  foo.
+",
+  "[?25h",
+]
+`;
+
 exports[`prompts (isCI = false) > spinner > stop > renders submit symbol and stops spinner 1`] = `
 [
   "[?25l",
@@ -3753,6 +3767,22 @@ exports[`prompts (isCI = true) > spinner > stop > renders message 1`] = `
   "[999D",
   "[J",
   "[32m◇[39m  foo
+",
+  "[?25h",
+]
+`;
+
+exports[`prompts (isCI = true) > spinner > stop > renders message without removing dots 1`] = `
+[
+  "[?25l",
+  "[90m│[39m
+",
+  "[35m◒[39m  ...",
+  "
+",
+  "[999D",
+  "[J",
+  "[32m◇[39m  foo.
 ",
   "[?25h",
 ]

--- a/packages/prompts/src/index.test.ts
+++ b/packages/prompts/src/index.test.ts
@@ -167,6 +167,18 @@ describe.each(['true', 'false'])('prompts (isCI = %s)', (isCI) => {
 
 				expect(output.buffer).toMatchSnapshot();
 			});
+
+			test('renders message without removing dots', () => {
+				const result = prompts.spinner({ output });
+
+				result.start();
+
+				vi.advanceTimersByTime(80);
+
+				result.stop('foo.');
+
+				expect(output.buffer).toMatchSnapshot();
+			});
 		});
 
 		describe('message', () => {

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -853,8 +853,8 @@ export const spinner = ({
 		output.write(erase.down(prevLines.length));
 	};
 
-	const parseMessage = (msg: string): string => {
-		return msg.replace(/\.+$/, '');
+	const parseMessage = (msg: string, noStrip = false): string => {
+		return noStrip ? msg : msg.replace(/\.+$/, '');
 	};
 
 	const formatTimer = (origin: number): string => {
@@ -905,7 +905,7 @@ export const spinner = ({
 				: code === 1
 					? color.red(S_STEP_CANCEL)
 					: color.red(S_STEP_ERROR);
-		_message = parseMessage(msg ?? _message);
+		_message = parseMessage(msg ?? _message, true);
 		if (indicator === 'timer') {
 			output.write(`${step}  ${_message} ${formatTimer(_origin)}\n`);
 		} else {

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -853,8 +853,8 @@ export const spinner = ({
 		output.write(erase.down(prevLines.length));
 	};
 
-	const parseMessage = (msg: string, noStrip = false): string => {
-		return noStrip ? msg : msg.replace(/\.+$/, '');
+	const removeTrailingDots = (msg: string): string => {
+		return msg.replace(/\.+$/, '');
 	};
 
 	const formatTimer = (origin: number): string => {
@@ -867,7 +867,7 @@ export const spinner = ({
 	const start = (msg = ''): void => {
 		isSpinnerActive = true;
 		unblock = block({ output });
-		_message = parseMessage(msg);
+		_message = removeTrailingDots(msg);
 		_origin = performance.now();
 		output.write(`${color.gray(S_BAR)}\n`);
 		let frameIndex = 0;
@@ -905,7 +905,7 @@ export const spinner = ({
 				: code === 1
 					? color.red(S_STEP_CANCEL)
 					: color.red(S_STEP_ERROR);
-		_message = parseMessage(msg ?? _message, true);
+		_message = msg ?? _message;
 		if (indicator === 'timer') {
 			output.write(`${step}  ${_message} ${formatTimer(_origin)}\n`);
 		} else {
@@ -916,7 +916,7 @@ export const spinner = ({
 	};
 
 	const message = (msg = ''): void => {
-		_message = parseMessage(msg ?? _message);
+		_message = removeTrailingDots(msg ?? _message);
 	};
 
 	return {


### PR DESCRIPTION
Fix #226 

---

~~Update `.editorconfig` to avoid trimming trailing space:~~
- ~~in `.snap` files as they contain "raw" CLI output~~
- ~~in `.md` files as `  `+<kbd>enter</kbd> is translated in `<br>`~~