### PR TITLE
test: separate cancel/error tests in progressbar/spinner

### DIFF
--- a/packages/prompts/test/__snapshots__/progress-bar.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/progress-bar.test.ts.snap
@@ -12,7 +12,7 @@ exports[`prompts - progress (isCI = false) > message > sets message for next fra
 ]
 `;
 
-exports[`prompts - progress (isCI = false) > process exit handling > prioritizes direct options over global settings 1`] = `
+exports[`prompts - progress (isCI = false) > process exit handling > prioritizes cancel option over global setting 1`] = `
 [
   "[?25l",
   "[90m│[39m
@@ -23,7 +23,7 @@ exports[`prompts - progress (isCI = false) > process exit handling > prioritizes
 ]
 `;
 
-exports[`prompts - progress (isCI = false) > process exit handling > prioritizes direct options over global settings 2`] = `
+exports[`prompts - progress (isCI = false) > process exit handling > prioritizes error option over global setting 1`] = `
 [
   "[?25l",
   "[90m│[39m
@@ -278,7 +278,7 @@ exports[`prompts - progress (isCI = true) > message > sets message for next fram
 ]
 `;
 
-exports[`prompts - progress (isCI = true) > process exit handling > prioritizes direct options over global settings 1`] = `
+exports[`prompts - progress (isCI = true) > process exit handling > prioritizes cancel option over global setting 1`] = `
 [
   "[?25l",
   "[90m│[39m
@@ -289,7 +289,7 @@ exports[`prompts - progress (isCI = true) > process exit handling > prioritizes 
 ]
 `;
 
-exports[`prompts - progress (isCI = true) > process exit handling > prioritizes direct options over global settings 2`] = `
+exports[`prompts - progress (isCI = true) > process exit handling > prioritizes error option over global setting 1`] = `
 [
   "[?25l",
   "[90m│[39m

--- a/packages/prompts/test/__snapshots__/spinner.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/spinner.test.ts.snap
@@ -12,7 +12,7 @@ exports[`spinner (isCI = false) > message > sets message for next frame 1`] = `
 ]
 `;
 
-exports[`spinner (isCI = false) > process exit handling > prioritizes direct options over global settings 1`] = `
+exports[`spinner (isCI = false) > process exit handling > prioritizes cancel option over global setting 1`] = `
 [
   "[?25l",
   "[90m│[39m
@@ -23,7 +23,7 @@ exports[`spinner (isCI = false) > process exit handling > prioritizes direct opt
 ]
 `;
 
-exports[`spinner (isCI = false) > process exit handling > prioritizes direct options over global settings 2`] = `
+exports[`spinner (isCI = false) > process exit handling > prioritizes error option over global setting 1`] = `
 [
   "[?25l",
   "[90m│[39m
@@ -209,7 +209,7 @@ exports[`spinner (isCI = true) > message > sets message for next frame 1`] = `
 ]
 `;
 
-exports[`spinner (isCI = true) > process exit handling > prioritizes direct options over global settings 1`] = `
+exports[`spinner (isCI = true) > process exit handling > prioritizes cancel option over global setting 1`] = `
 [
   "[?25l",
   "[90m│[39m
@@ -220,7 +220,7 @@ exports[`spinner (isCI = true) > process exit handling > prioritizes direct opti
 ]
 `;
 
-exports[`spinner (isCI = true) > process exit handling > prioritizes direct options over global settings 2`] = `
+exports[`spinner (isCI = true) > process exit handling > prioritizes error option over global setting 1`] = `
 [
   "[?25l",
   "[90m│[39m

--- a/packages/prompts/test/progress-bar.test.ts
+++ b/packages/prompts/test/progress-bar.test.ts
@@ -209,72 +209,83 @@ describe.each(['true', 'false'])('prompts - progress (isCI = %s)', (isCI) => {
 		test('uses global custom cancel message from settings', () => {
 			// Store original message
 			const originalCancelMessage = prompts.settings.messages.cancel;
-			// Set custom message
-			prompts.settings.messages.cancel = 'Global cancel message';
+			try {
+				// Set custom message
+				prompts.settings.messages.cancel = 'Global cancel message';
 
-			const result = prompts.progress({ output });
-			result.start('Test operation');
+				const result = prompts.progress({ output });
+				result.start('Test operation');
 
-			processEmitter.emit('SIGINT');
+				processEmitter.emit('SIGINT');
 
-			expect(output.buffer).toMatchSnapshot();
-
-			// Reset to original
-			prompts.settings.messages.cancel = originalCancelMessage;
+				expect(output.buffer).toMatchSnapshot();
+			} finally {
+				// Reset to original
+				prompts.settings.messages.cancel = originalCancelMessage;
+			}
 		});
 
 		test('uses global custom error message from settings', () => {
 			// Store original message
 			const originalErrorMessage = prompts.settings.messages.error;
-			// Set custom message
-			prompts.settings.messages.error = 'Global error message';
+			try {
+				// Set custom message
+				prompts.settings.messages.error = 'Global error message';
 
-			const result = prompts.progress({ output });
-			result.start('Test operation');
+				const result = prompts.progress({ output });
+				result.start('Test operation');
 
-			processEmitter.emit('exit', 2);
+				processEmitter.emit('exit', 2);
 
-			expect(output.buffer).toMatchSnapshot();
-
-			// Reset to original
-			prompts.settings.messages.error = originalErrorMessage;
+				expect(output.buffer).toMatchSnapshot();
+			} finally {
+				// Reset to original
+				prompts.settings.messages.error = originalErrorMessage;
+			}
 		});
 
-		test('prioritizes direct options over global settings', () => {
+		test('prioritizes error option over global setting', () => {
 			// Store original messages
-			const originalCancelMessage = prompts.settings.messages.cancel;
 			const originalErrorMessage = prompts.settings.messages.error;
 
-			// Set custom global messages
-			prompts.settings.messages.cancel = 'Global cancel message';
-			prompts.settings.messages.error = 'Global error message';
+			try {
+				// Set custom global messages
+				prompts.settings.messages.error = 'Global error message';
 
-			const result = prompts.progress({
-				output,
-				cancelMessage: 'Progress cancel message',
-				errorMessage: 'Progress error message',
-			});
-			result.start('Test operation');
+				const result = prompts.progress({
+					output,
+					errorMessage: 'Progress error message',
+				});
+				result.start('Test operation');
 
-			processEmitter.emit('SIGINT');
-			expect(output.buffer).toMatchSnapshot();
+				processEmitter.emit('exit', 2);
+				expect(output.buffer).toMatchSnapshot();
+			} finally {
+				// Reset to original values
+				prompts.settings.messages.error = originalErrorMessage;
+			}
+		});
 
-			// Reset buffer
-			output.buffer = [];
+		test('prioritizes cancel option over global setting', () => {
+			// Store original messages
+			const originalCancelMessage = prompts.settings.messages.cancel;
 
-			const result2 = prompts.progress({
-				output,
-				cancelMessage: 'Progress cancel message',
-				errorMessage: 'Progress error message',
-			});
-			result2.start('Test operation');
+			try {
+				// Set custom global messages
+				prompts.settings.messages.cancel = 'Global cancel message';
 
-			processEmitter.emit('exit', 2);
-			expect(output.buffer).toMatchSnapshot();
+				const result = prompts.progress({
+					output,
+					cancelMessage: 'Progress cancel message',
+				});
+				result.start('Test operation');
 
-			// Reset to original values
-			prompts.settings.messages.cancel = originalCancelMessage;
-			prompts.settings.messages.error = originalErrorMessage;
+				processEmitter.emit('SIGINT');
+				expect(output.buffer).toMatchSnapshot();
+			} finally {
+				// Reset to original values
+				prompts.settings.messages.cancel = originalCancelMessage;
+			}
 		});
 	});
 

--- a/packages/prompts/test/spinner.test.ts
+++ b/packages/prompts/test/spinner.test.ts
@@ -206,72 +206,84 @@ describe.each(['true', 'false'])('spinner (isCI = %s)', (isCI) => {
 		test('uses global custom cancel message from settings', () => {
 			// Store original message
 			const originalCancelMessage = prompts.settings.messages.cancel;
-			// Set custom message
-			prompts.settings.messages.cancel = 'Global cancel message';
+			try {
+				// Set custom message
+				prompts.settings.messages.cancel = 'Global cancel message';
 
-			const result = prompts.spinner({ output });
-			result.start('Test operation');
+				const result = prompts.spinner({ output });
+				result.start('Test operation');
 
-			processEmitter.emit('SIGINT');
+				processEmitter.emit('SIGINT');
 
-			expect(output.buffer).toMatchSnapshot();
-
-			// Reset to original
-			prompts.settings.messages.cancel = originalCancelMessage;
+				expect(output.buffer).toMatchSnapshot();
+			} finally {
+				// Reset to original
+				prompts.settings.messages.cancel = originalCancelMessage;
+			}
 		});
 
 		test('uses global custom error message from settings', () => {
 			// Store original message
 			const originalErrorMessage = prompts.settings.messages.error;
-			// Set custom message
-			prompts.settings.messages.error = 'Global error message';
 
-			const result = prompts.spinner({ output });
-			result.start('Test operation');
+			try {
+				// Set custom message
+				prompts.settings.messages.error = 'Global error message';
 
-			processEmitter.emit('exit', 2);
+				const result = prompts.spinner({ output });
+				result.start('Test operation');
 
-			expect(output.buffer).toMatchSnapshot();
+				processEmitter.emit('exit', 2);
 
-			// Reset to original
-			prompts.settings.messages.error = originalErrorMessage;
+				expect(output.buffer).toMatchSnapshot();
+			} finally {
+				// Reset to original
+				prompts.settings.messages.error = originalErrorMessage;
+			}
 		});
 
-		test('prioritizes direct options over global settings', () => {
+		test('prioritizes error option over global setting', () => {
 			// Store original messages
-			const originalCancelMessage = prompts.settings.messages.cancel;
 			const originalErrorMessage = prompts.settings.messages.error;
 
-			// Set custom global messages
-			prompts.settings.messages.cancel = 'Global cancel message';
-			prompts.settings.messages.error = 'Global error message';
+			try {
+				// Set custom global messages
+				prompts.settings.messages.error = 'Global error message';
 
-			const result = prompts.spinner({
-				output,
-				cancelMessage: 'Spinner cancel message',
-				errorMessage: 'Spinner error message',
-			});
-			result.start('Test operation');
+				const result = prompts.spinner({
+					output,
+					errorMessage: 'Spinner error message',
+				});
+				result.start('Test operation');
 
-			processEmitter.emit('SIGINT');
-			expect(output.buffer).toMatchSnapshot();
+				processEmitter.emit('exit', 2);
+				expect(output.buffer).toMatchSnapshot();
+			} finally {
+				// Reset to original values
+				prompts.settings.messages.error = originalErrorMessage;
+			}
+		});
 
-			// Reset buffer
-			output.buffer = [];
+		test('prioritizes cancel option over global setting', () => {
+			// Store original messages
+			const originalCancelMessage = prompts.settings.messages.cancel;
 
-			const result2 = prompts.spinner({
-				output,
-				cancelMessage: 'Spinner cancel message',
-				errorMessage: 'Spinner error message',
-			});
-			result2.start('Test operation');
+			try {
+				// Set custom global messages
+				prompts.settings.messages.cancel = 'Global cancel message';
 
-			processEmitter.emit('exit', 2);
-			expect(output.buffer).toMatchSnapshot();
+				const result = prompts.spinner({
+					output,
+					cancelMessage: 'Spinner cancel message',
+				});
+				result.start('Test operation');
 
-			// Reset to original values
-			prompts.settings.messages.cancel = originalCancelMessage;
-			prompts.settings.messages.error = originalErrorMessage;
+				processEmitter.emit('SIGINT');
+				expect(output.buffer).toMatchSnapshot();
+			} finally {
+				// Reset to original values
+				prompts.settings.messages.cancel = originalCancelMessage;
+			}
 		});
 	});
 });


### PR DESCRIPTION
These should be two tests. Otherwise, if one fails mid-way through, vitest will think the later snapshot is obsolete and could risk someone removing it by pressing 'u'.

depends on #299 