### PR TITLE
chore: temporarily drop JSR release

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "type-check": "biome lint && tsc",
     "test": "pnpm --color -r run test",
     "ci:install": "pnpm install --no-frozen-lockfile",
-    "ci:version": "changeset version && pnpx @qingshaner/jsr-release --allowDirty version --sync",
+    "ci:version": "changeset version",
     "ci:publish": "changeset publish",
     "ci:prepublish": "pnpm build",
     "deps:check": "pnpm exec knip --production",


### PR DESCRIPTION
It fails anyway, so we should remove it for now until we get time to fix it.