### PR TITLE
fix: treat placeholders as visual element

### DIFF
--- a/.changeset/mean-turkeys-help.md
+++ b/.changeset/mean-turkeys-help.md
@@ -1,0 +1,6 @@
+---
+"@clack/prompts": patch
+"@clack/core": patch
+---
+
+Changes `placeholder` to be a visual hint rather than a tabbable value.

--- a/packages/core/src/prompts/autocomplete.ts
+++ b/packages/core/src/prompts/autocomplete.ts
@@ -84,7 +84,6 @@ export default class AutocompletePrompt<T extends OptionLike> extends Prompt {
 		this.options = opts.options;
 		this.filteredOptions = [...this.options];
 		this.multiple = opts.multiple === true;
-		this._usePlaceholderAsValue = false;
 		this.#filterFn = opts.filter ?? defaultFilter;
 		let initialValues: unknown[] | undefined;
 		if (opts.initialValue && Array.isArray(opts.initialValue)) {
@@ -93,6 +92,8 @@ export default class AutocompletePrompt<T extends OptionLike> extends Prompt {
 			} else {
 				initialValues = opts.initialValue.slice(0, 1);
 			}
+		} else if (!this.multiple && this.options.length > 0) {
+			initialValues = [this.options[0].value];
 		}
 
 		if (initialValues) {

--- a/packages/core/src/prompts/prompt.ts
+++ b/packages/core/src/prompts/prompt.ts
@@ -12,9 +12,7 @@ import type { Action } from '../utils/index.js';
 
 export interface PromptOptions<Self extends Prompt> {
 	render(this: Omit<Self, 'prompt'>): string | undefined;
-	placeholder?: string;
 	initialValue?: any;
-	defaultValue?: any;
 	validate?: ((value: any) => string | Error | undefined) | undefined;
 	input?: Readable;
 	output?: Writable;
@@ -34,7 +32,6 @@ export default class Prompt {
 	private _prevFrame = '';
 	private _subscribers = new Map<string, { cb: (...args: any) => any; once?: boolean }[]>();
 	protected _cursor = 0;
-	protected _usePlaceholderAsValue = true;
 
 	public state: ClackState = 'initial';
 	public error = '';
@@ -212,25 +209,11 @@ export default class Prompt {
 		if (char && (char.toLowerCase() === 'y' || char.toLowerCase() === 'n')) {
 			this.emit('confirm', char.toLowerCase() === 'y');
 		}
-		if (this._usePlaceholderAsValue && char === '\t' && this.opts.placeholder) {
-			if (!this.value) {
-				this.rl?.write(this.opts.placeholder);
-				this._setValue(this.opts.placeholder);
-			}
-		}
 
 		// Call the key event handler and emit the key event
 		this.emit('key', char?.toLowerCase(), key);
 
 		if (key?.name === 'return') {
-			if (!this.value) {
-				if (this.opts.defaultValue) {
-					this._setValue(this.opts.defaultValue);
-				} else {
-					this._setValue('');
-				}
-			}
-
 			if (this.opts.validate) {
 				const problem = this.opts.validate(this.value);
 				if (problem) {

--- a/packages/core/test/prompts/prompt.test.ts
+++ b/packages/core/test/prompts/prompt.test.ts
@@ -38,7 +38,7 @@ describe('Prompt', () => {
 		const resultPromise = instance.prompt();
 		input.emit('keypress', '', { name: 'return' });
 		const result = await resultPromise;
-		expect(result).to.equal('');
+		expect(result).to.equal(undefined);
 		expect(isCancel(result)).to.equal(false);
 		expect(instance.state).to.equal('submit');
 		expect(output.buffer).to.deep.equal([cursor.hide, 'foo', '\n', cursor.show]);
@@ -134,37 +134,6 @@ describe('Prompt', () => {
 		input.emit('keypress', 'n', { name: 'n' });
 
 		expect(eventFn).toBeCalledWith(false);
-	});
-
-	test('sets value as placeholder on tab if one is set', () => {
-		const instance = new Prompt({
-			input,
-			output,
-			render: () => 'foo',
-			placeholder: 'piwa',
-		});
-
-		instance.prompt();
-
-		input.emit('keypress', '\t', { name: 'tab' });
-
-		expect(instance.value).to.equal('piwa');
-	});
-
-	test('does not set placeholder value on tab if value already set', () => {
-		const instance = new Prompt({
-			input,
-			output,
-			render: () => 'foo',
-			placeholder: 'piwa',
-			initialValue: 'trzy',
-		});
-
-		instance.prompt();
-
-		input.emit('keypress', '\t', { name: 'tab' });
-
-		expect(instance.value).to.equal('trzy');
 	});
 
 	test('emits key event for unknown chars', () => {

--- a/packages/prompts/src/autocomplete.ts
+++ b/packages/prompts/src/autocomplete.ts
@@ -67,7 +67,6 @@ export interface AutocompleteOptions<Value> extends CommonOptions {
 export const autocomplete = <Value>(opts: AutocompleteOptions<Value>) => {
 	const prompt = new AutocompletePrompt({
 		options: opts.options,
-		placeholder: opts.placeholder,
 		initialValue: opts.initialValue ? [opts.initialValue] : undefined,
 		filter: (search: string, opt: Option<Value>) => {
 			return getFilteredOption(search, opt);
@@ -78,6 +77,8 @@ export const autocomplete = <Value>(opts: AutocompleteOptions<Value>) => {
 			// Title and message display
 			const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;
 			const valueAsString = String(this.value ?? '');
+			const placeholder = opts.placeholder;
+			const showPlaceholder = valueAsString === '' && placeholder !== undefined;
 
 			// Handle different states
 			switch (this.state) {
@@ -94,7 +95,10 @@ export const autocomplete = <Value>(opts: AutocompleteOptions<Value>) => {
 
 				default: {
 					// Display cursor position - show plain text in navigation mode
-					const searchText = this.isNavigating ? color.dim(valueAsString) : this.valueWithCursor;
+					const searchText =
+						this.isNavigating || showPlaceholder
+							? color.dim(showPlaceholder ? placeholder : valueAsString)
+							: this.valueWithCursor;
 
 					// Show match count if filtered
 					const matches =
@@ -220,7 +224,6 @@ export const autocompleteMultiselect = <Value>(opts: AutocompleteMultiSelectOpti
 		filter: (search, opt) => {
 			return getFilteredOption(search, opt);
 		},
-		placeholder: opts.placeholder,
 		initialValue: opts.initialValues,
 		input: opts.input,
 		output: opts.output,
@@ -229,16 +232,15 @@ export const autocompleteMultiselect = <Value>(opts: AutocompleteMultiSelectOpti
 			const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;
 
 			// Selection counter
-			const counter =
-				this.selectedValues.length > 0
-					? color.cyan(` (${this.selectedValues.length} selected)`)
-					: '';
 			const value = String(this.value ?? '');
+			const placeholder = opts.placeholder;
+			const showPlaceholder = value === '' && placeholder !== undefined;
 
 			// Search input display
-			const searchText = this.isNavigating
-				? color.dim(value) // Just show plain text when in navigation mode
-				: this.valueWithCursor;
+			const searchText =
+				this.isNavigating || showPlaceholder
+					? color.dim(showPlaceholder ? placeholder : value) // Just show plain text when in navigation mode
+					: this.valueWithCursor;
 
 			const matches =
 				this.filteredOptions.length !== opts.options.length

--- a/packages/prompts/src/text.ts
+++ b/packages/prompts/src/text.ts
@@ -31,7 +31,7 @@ export const text = (opts: TextOptions) => {
 						S_BAR_END
 					)}  ${color.yellow(this.error)}\n`;
 				case 'submit': {
-					const displayValue = typeof this.value === 'undefined' ? '' : this.value;
+					const displayValue = this.value === undefined ? '' : this.value;
 					return `${title}${color.gray(S_BAR)}  ${color.dim(displayValue)}`;
 				}
 				case 'cancel':

--- a/packages/prompts/test/__snapshots__/autocomplete.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/autocomplete.test.ts.snap
@@ -35,6 +35,31 @@ exports[`autocomplete > renders initial UI with message and instructions 1`] = `
 ]
 `;
 
+exports[`autocomplete > renders placeholder if set 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  Select a fruit
+
+[36m│[39m  [2mSearch:[22m [2mType to search...[22m
+[36m│[39m  [32m●[39m Apple
+[36m│[39m  [2m○[22m [2mBanana[22m
+[36m│[39m  [2m○[22m [2mCherry[22m
+[36m│[39m  [2m○[22m [2mGrape[22m
+[36m│[39m  [2m○[22m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=10>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  Select a fruit
+[90m│[39m  [2mApple[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
 exports[`autocomplete > shows hint when option has hint and is focused 1`] = `
 [
   "<cursor.hide>",

--- a/packages/prompts/test/autocomplete.test.ts
+++ b/packages/prompts/test/autocomplete.test.ts
@@ -120,4 +120,20 @@ describe('autocomplete', () => {
 		expect(typeof value === 'symbol').toBe(true);
 		expect(output.buffer).toMatchSnapshot();
 	});
+
+	test('renders placeholder if set', async () => {
+		const result = autocomplete({
+			message: 'Select a fruit',
+			placeholder: 'Type to search...',
+			options: testOptions,
+			input,
+			output,
+		});
+
+		input.emit('keypress', '', { name: 'return' });
+		const value = await result;
+
+		expect(output.buffer).toMatchSnapshot();
+		expect(value).toBe('apple');
+	});
 });

--- a/packages/prompts/test/text.test.ts
+++ b/packages/prompts/test/text.test.ts
@@ -55,22 +55,6 @@ describe.each(['true', 'false'])('text (isCI = %s)', (isCI) => {
 		expect(value).toBe('');
 	});
 
-	test('<tab> applies placeholder', async () => {
-		const result = prompts.text({
-			message: 'foo',
-			placeholder: 'bar',
-			input,
-			output,
-		});
-
-		input.emit('keypress', '\t', { name: 'tab' });
-		input.emit('keypress', '', { name: 'return' });
-
-		const value = await result;
-
-		expect(value).toBe('bar');
-	});
-
 	test('can cancel', async () => {
 		const result = prompts.text({
 			message: 'foo',


### PR DESCRIPTION
This changes how we deal with placeholders.

Currently, a placeholder behaves as a visual hint of what we want the user to type. It also behaves as an optional default value, in that you can press `<Enter>` or `<Tab>` to insert it as the value.

This is confusing since it means it is a "partial" default value, and a placeholder at the same time.

This change basically removes the placeholder logic from core, such that the `text` and `autocomplete` prompts use `placeholder` purely as a render/visual hint.

This updated behaviour means we render the placeholder when no value is set, but it can no longer be inserted as a value. To achieve that, you should combine `defaultValue` with `placeholder` (i.e. set them to the same value).

cc @dreyfus92 @natemoo-re 