### PR TITLE
feat: add `required` option to autocomplete multiselect

### DIFF
--- a/packages/prompts/test/__snapshots__/autocomplete.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/autocomplete.test.ts.snap
@@ -15,6 +15,14 @@ exports[`autocomplete > limits displayed options when maxItems is set 1`] = `
 [36m│[39m  [2m...[22m
 [36m│[39m  [2m[2m↑/↓[22m[2m to select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
+  "<cursor.backward count=999><cursor.up count=11>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  Select an option
+[90m│[39m[2m[22m",
+  "
+",
+  "<cursor.show>",
 ]
 `;
 
@@ -32,6 +40,14 @@ exports[`autocomplete > renders initial UI with message and instructions 1`] = `
 [36m│[39m  [2m○[22m [2mOrange[22m
 [36m│[39m  [2m[2m↑/↓[22m[2m to select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
+  "<cursor.backward count=999><cursor.up count=10>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  Select a fruit
+[90m│[39m[2m[22m",
+  "
+",
+  "<cursor.show>",
 ]
 `;
 
@@ -96,6 +112,14 @@ exports[`autocomplete > shows hint when option has hint and is focused 1`] = `
 [36m│[39m  [32m●[39m Kiwi[2m (New Zealand)[22m
 [36m│[39m  [2m[2m↑/↓[22m[2m to select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
+  "<cursor.backward count=999><cursor.up count=11>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  Select a fruit
+[90m│[39m  [2mKiwi[22m",
+  "
+",
+  "<cursor.show>",
 ]
 `;
 
@@ -120,6 +144,14 @@ exports[`autocomplete > shows no matches message when search has no results 1`] 
 [36m│[39m  [33mNo matches found[39m
 [36m│[39m  [2m[2m↑/↓[22m[2m to select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
+  "<cursor.backward count=999><cursor.up count=6>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  Select a fruit
+[90m│[39m[2m[22m",
+  "
+",
+  "<cursor.show>",
 ]
 `;
 
@@ -178,6 +210,58 @@ exports[`autocomplete > shows strikethrough in cancel state 1`] = `
   "<erase.down>",
   "[31m■[39m  Select a fruit
 [90m│[39m[9m[2m[22m[29m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`autocompleteMultiselect > renders error when empty selection & required is true 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  Select a fruit
+
+[36m│[39m  [2mSearch:[22m [7m[8m_[28m[27m
+[36m│[39m  [2m◻[22m Apple
+[36m│[39m  [2m◻[22m [2mBanana[22m
+[36m│[39m  [2m◻[22m [2mCherry[22m
+[36m│[39m  [2m◻[22m [2mGrape[22m
+[36m│[39m  [2m◻[22m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=10>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[33m▲[39m  Select a fruit
+
+[36m│[39m  [2mSearch:[22m [7m[8m_[28m[27m
+[36m│[39m  [33mPlease select at least one item[39m
+[36m│[39m  [2m◻[22m Apple
+[36m│[39m  [2m◻[22m [2mBanana[22m
+[36m│[39m  [2m◻[22m [2mCherry[22m
+[36m│[39m  [2m◻[22m [2mGrape[22m
+[36m│[39m  [2m◻[22m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=11>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[36m◆[39m  Select a fruit
+
+[36m│[39m  [2mSearch:[22m [7m[8m_[28m[27m
+[36m│[39m  [32m◼[39m Apple
+[36m│[39m  [2m◻[22m [2mBanana[22m
+[36m│[39m  [2m◻[22m [2mCherry[22m
+[36m│[39m  [2m◻[22m [2mGrape[22m
+[36m│[39m  [2m◻[22m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=10>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  Select a fruit
+[90m│[39m  [2m1 items selected[22m",
   "
 ",
   "<cursor.show>",

--- a/packages/prompts/test/autocomplete.test.ts
+++ b/packages/prompts/test/autocomplete.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { autocomplete } from '../src/autocomplete.js';
+import { autocomplete, autocompleteMultiselect } from '../src/autocomplete.js';
 import { MockReadable, MockWritable } from './test-utils.js';
 
 describe('autocomplete', () => {
@@ -30,9 +30,9 @@ describe('autocomplete', () => {
 			output,
 		});
 
-		expect(output.buffer).toMatchSnapshot();
 		input.emit('keypress', '', { name: 'return' });
 		await result;
+		expect(output.buffer).toMatchSnapshot();
 	});
 
 	test('limits displayed options when maxItems is set', async () => {
@@ -49,9 +49,9 @@ describe('autocomplete', () => {
 			output,
 		});
 
-		expect(output.buffer).toMatchSnapshot();
 		input.emit('keypress', '', { name: 'return' });
 		await result;
+		expect(output.buffer).toMatchSnapshot();
 	});
 
 	test('shows no matches message when search has no results', async () => {
@@ -64,9 +64,9 @@ describe('autocomplete', () => {
 
 		// Type something that won't match
 		input.emit('keypress', 'z', { name: 'z' });
-		expect(output.buffer).toMatchSnapshot();
 		input.emit('keypress', '', { name: 'return' });
 		await result;
+		expect(output.buffer).toMatchSnapshot();
 	});
 
 	test('shows hint when option has hint and is focused', async () => {
@@ -83,9 +83,9 @@ describe('autocomplete', () => {
 		input.emit('keypress', '', { name: 'down' });
 		input.emit('keypress', '', { name: 'down' });
 		input.emit('keypress', '', { name: 'down' });
-		expect(output.buffer).toMatchSnapshot();
 		input.emit('keypress', '', { name: 'return' });
 		await result;
+		expect(output.buffer).toMatchSnapshot();
 	});
 
 	test('shows selected value in submit state', async () => {
@@ -118,6 +118,43 @@ describe('autocomplete', () => {
 
 		const value = await result;
 		expect(typeof value === 'symbol').toBe(true);
+		expect(output.buffer).toMatchSnapshot();
+	});
+});
+
+describe('autocompleteMultiselect', () => {
+	let input: MockReadable;
+	let output: MockWritable;
+	const testOptions = [
+		{ value: 'apple', label: 'Apple' },
+		{ value: 'banana', label: 'Banana' },
+		{ value: 'cherry', label: 'Cherry' },
+		{ value: 'grape', label: 'Grape' },
+		{ value: 'orange', label: 'Orange' },
+	];
+
+	beforeEach(() => {
+		input = new MockReadable();
+		output = new MockWritable();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	test('renders error when empty selection & required is true', async () => {
+		const result = autocompleteMultiselect({
+			message: 'Select a fruit',
+			options: testOptions,
+			required: true,
+			input,
+			output,
+		});
+
+		input.emit('keypress', '', { name: 'return' });
+		input.emit('keypress', '', { name: 'tab' });
+		input.emit('keypress', '', { name: 'return' });
+		await result;
 		expect(output.buffer).toMatchSnapshot();
 	});
 });


### PR DESCRIPTION
Adds a new `required` option to the autocomplete multiselect prompt.

When set, this will show an error if no options are selected.

Fixes #327