### PR TITLE
fix(autocomplete): use first option as initial value in non-multiple

### DIFF
--- a/.changeset/moody-baboons-greet.md
+++ b/.changeset/moody-baboons-greet.md
@@ -1,0 +1,5 @@
+---
+"@clack/core": patch
+---
+
+Set initial values of auto complete prompt to first option when multiple is false.

--- a/packages/core/src/prompts/autocomplete.ts
+++ b/packages/core/src/prompts/autocomplete.ts
@@ -96,6 +96,10 @@ export default class AutocompletePrompt<T extends OptionLike> extends Prompt {
 			} else {
 				initialValues = opts.initialValue.slice(0, 1);
 			}
+		} else {
+			if (!this.multiple && this.options.length > 0) {
+				initialValues = [this.options[0].value];
+			}
 		}
 
 		if (initialValues) {
@@ -151,14 +155,19 @@ export default class AutocompletePrompt<T extends OptionLike> extends Prompt {
 			}
 			this.isNavigating = true;
 		} else {
-			if (
-				this.multiple &&
-				this.focusedValue !== undefined &&
-				(key.name === 'tab' || (this.isNavigating && key.name === 'space'))
-			) {
-				this.toggleSelected(this.focusedValue);
+			if (this.multiple) {
+				if (
+					this.focusedValue !== undefined &&
+					(key.name === 'tab' || (this.isNavigating && key.name === 'space'))
+				) {
+					this.toggleSelected(this.focusedValue);
+				} else {
+					this.isNavigating = false;
+				}
 			} else {
-				this.isNavigating = false;
+				if (this.focusedValue) {
+					this.selectedValues = [this.focusedValue];
+				}
 			}
 		}
 	}

--- a/packages/core/test/prompts/autocomplete.test.ts
+++ b/packages/core/test/prompts/autocomplete.test.ts
@@ -93,6 +93,31 @@ describe('AutocompletePrompt', () => {
 		expect(instance.selectedValues).to.deep.equal(['cherry']);
 	});
 
+	test('initialValue defaults to first option when non-multiple', () => {
+		const instance = new AutocompletePrompt({
+			input,
+			output,
+			render: () => 'foo',
+			options: testOptions,
+		});
+
+		expect(instance.cursor).to.equal(0);
+		expect(instance.selectedValues).to.deep.equal(['apple']);
+	});
+
+	test('initialValue is empty when multiple', () => {
+		const instance = new AutocompletePrompt({
+			input,
+			output,
+			render: () => 'foo',
+			options: testOptions,
+			multiple: true,
+		});
+
+		expect(instance.cursor).to.equal(0);
+		expect(instance.selectedValues).to.deep.equal([]);
+	});
+
 	test('filtering through value event', () => {
 		const instance = new AutocompletePrompt({
 			input,
@@ -135,5 +160,38 @@ describe('AutocompletePrompt', () => {
 		instance.emit('value', 'z');
 
 		expect(instance.filteredOptions).toEqual([]);
+	});
+
+	test('submit without nav resolves to first option in non-multiple', async () => {
+		const instance = new AutocompletePrompt({
+			input,
+			output,
+			render: () => 'foo',
+			options: testOptions,
+		});
+
+		const promise = instance.prompt();
+		input.emit('keypress', '', { name: 'return' });
+		const result = await promise;
+
+		expect(instance.selectedValues).to.deep.equal(['apple']);
+		expect(result).to.equal('apple');
+	});
+
+	test('submit without nav resolves to [] in multiple', async () => {
+		const instance = new AutocompletePrompt({
+			input,
+			output,
+			render: () => 'foo',
+			options: testOptions,
+			multiple: true,
+		});
+
+		const promise = instance.prompt();
+		input.emit('keypress', '', { name: 'return' });
+		const result = await promise;
+
+		expect(instance.selectedValues).to.deep.equal([]);
+		expect(result).to.deep.equal([]);
 	});
 });


### PR DESCRIPTION
When `multiple: false` of an auto complete prompt, we should be setting the initial value (i.e. the selected value) as the first one in the list.

This way, when pressing `<RETURN>` without any movement, the result will be the first value.

When `multiple: true`, this will leave the result as `[]`.

Fixes #331