### PR TITLE
feat: rework values and user input to be separate

### DIFF
--- a/packages/core/src/prompts/autocomplete.ts
+++ b/packages/core/src/prompts/autocomplete.ts
@@ -44,13 +44,16 @@ function normalisedValue<T>(multiple: boolean, values: T[] | undefined): T | T[]
 	return values[0];
 }
 
-interface AutocompleteOptions<T extends OptionLike> extends PromptOptions<T['value'] | T['value'][], AutocompletePrompt<T>> {
+interface AutocompleteOptions<T extends OptionLike>
+	extends PromptOptions<T['value'] | T['value'][], AutocompletePrompt<T>> {
 	options: T[];
 	filter?: FilterFunction<T>;
 	multiple?: boolean;
 }
 
-export default class AutocompletePrompt<T extends OptionLike> extends Prompt<T['value'] | T['value'][]> {
+export default class AutocompletePrompt<T extends OptionLike> extends Prompt<
+	T['value'] | T['value'][]
+> {
 	options: T[];
 	filteredOptions: T[];
 	multiple: boolean;
@@ -59,7 +62,7 @@ export default class AutocompletePrompt<T extends OptionLike> extends Prompt<T['
 
 	focusedValue: T['value'] | undefined;
 	#cursor = 0;
-	#lastUserInput: string = '';
+	#lastUserInput = '';
 	#filterFn: FilterFunction<T>;
 
 	get cursor(): number {

--- a/packages/core/src/prompts/autocomplete.ts
+++ b/packages/core/src/prompts/autocomplete.ts
@@ -82,10 +82,7 @@ export default class AutocompletePrompt<T extends OptionLike> extends Prompt<
 	}
 
 	constructor(opts: AutocompleteOptions<T>) {
-		super({
-			...opts,
-			initialValue: undefined,
-		});
+		super(opts);
 
 		this.options = opts.options;
 		this.filteredOptions = [...this.options];
@@ -105,16 +102,16 @@ export default class AutocompletePrompt<T extends OptionLike> extends Prompt<
 		}
 
 		if (initialValues) {
-			this.selectedValues = initialValues;
 			for (const selectedValue of initialValues) {
 				const selectedIndex = this.options.findIndex((opt) => opt.value === selectedValue);
 				if (selectedIndex !== -1) {
 					this.toggleSelected(selectedValue);
 					this.#cursor = selectedIndex;
-					this.focusedValue = this.options[this.#cursor]?.value;
 				}
 			}
 		}
+
+		this.focusedValue = this.options[this.#cursor]?.value;
 
 		this.on('finalize', () => {
 			if (!this.value) {

--- a/packages/core/src/prompts/autocomplete.ts
+++ b/packages/core/src/prompts/autocomplete.ts
@@ -44,13 +44,13 @@ function normalisedValue<T>(multiple: boolean, values: T[] | undefined): T | T[]
 	return values[0];
 }
 
-interface AutocompleteOptions<T extends OptionLike> extends PromptOptions<AutocompletePrompt<T>> {
+interface AutocompleteOptions<T extends OptionLike> extends PromptOptions<T['value'] | T['value'][], AutocompletePrompt<T>> {
 	options: T[];
 	filter?: FilterFunction<T>;
 	multiple?: boolean;
 }
 
-export default class AutocompletePrompt<T extends OptionLike> extends Prompt {
+export default class AutocompletePrompt<T extends OptionLike> extends Prompt<T['value'] | T['value'][]> {
 	options: T[];
 	filteredOptions: T[];
 	multiple: boolean;
@@ -59,22 +59,22 @@ export default class AutocompletePrompt<T extends OptionLike> extends Prompt {
 
 	focusedValue: T['value'] | undefined;
 	#cursor = 0;
-	#lastValue: T['value'] | undefined;
+	#lastUserInput: string = '';
 	#filterFn: FilterFunction<T>;
 
 	get cursor(): number {
 		return this.#cursor;
 	}
 
-	get valueWithCursor() {
-		if (!this.value) {
+	get userInputWithCursor() {
+		if (!this.userInput) {
 			return color.inverse(color.hidden('_'));
 		}
-		if (this._cursor >= this.value.length) {
-			return `${this.value}█`;
+		if (this._cursor >= this.userInput.length) {
+			return `${this.userInput}█`;
 		}
-		const s1 = this.value.slice(0, this._cursor);
-		const [s2, ...s3] = this.value.slice(this._cursor);
+		const s1 = this.userInput.slice(0, this._cursor);
+		const [s2, ...s3] = this.userInput.slice(this._cursor);
 		return `${s1}${color.inverse(s2)}${s3.join('')}`;
 	}
 
@@ -118,7 +118,7 @@ export default class AutocompletePrompt<T extends OptionLike> extends Prompt {
 		});
 
 		this.on('key', (char, key) => this.#onKey(char, key));
-		this.on('value', (value) => this.#onValueChanged(value));
+		this.on('userInput', (value) => this.#onUserInputChanged(value));
 	}
 
 	protected override _isActionKey(char: string | undefined, key: Key): boolean {
@@ -176,9 +176,9 @@ export default class AutocompletePrompt<T extends OptionLike> extends Prompt {
 		}
 	}
 
-	#onValueChanged(value: string | undefined): void {
-		if (value !== this.#lastValue) {
-			this.#lastValue = value;
+	#onUserInputChanged(value: string): void {
+		if (value !== this.#lastUserInput) {
+			this.#lastUserInput = value;
 
 			if (value) {
 				this.filteredOptions = this.options.filter((opt) => this.#filterFn(value, opt));

--- a/packages/core/src/prompts/confirm.ts
+++ b/packages/core/src/prompts/confirm.ts
@@ -1,12 +1,12 @@
 import { cursor } from 'sisteransi';
 import Prompt, { type PromptOptions } from './prompt.js';
 
-interface ConfirmOptions extends PromptOptions<ConfirmPrompt> {
+interface ConfirmOptions extends PromptOptions<boolean, ConfirmPrompt> {
 	active: string;
 	inactive: string;
 	initialValue?: boolean;
 }
-export default class ConfirmPrompt extends Prompt {
+export default class ConfirmPrompt extends Prompt<boolean> {
 	get cursor() {
 		return this.value ? 0 : 1;
 	}
@@ -19,7 +19,7 @@ export default class ConfirmPrompt extends Prompt {
 		super(opts, false);
 		this.value = !!opts.initialValue;
 
-		this.on('value', () => {
+		this.on('userInput', () => {
 			this.value = this._value;
 		});
 

--- a/packages/core/src/prompts/group-multiselect.ts
+++ b/packages/core/src/prompts/group-multiselect.ts
@@ -1,14 +1,14 @@
 import Prompt, { type PromptOptions } from './prompt.js';
 
 interface GroupMultiSelectOptions<T extends { value: any }>
-	extends PromptOptions<GroupMultiSelectPrompt<T>> {
+	extends PromptOptions<T['value'][], GroupMultiSelectPrompt<T>> {
 	options: Record<string, T[]>;
 	initialValues?: T['value'][];
 	required?: boolean;
 	cursorAt?: T['value'];
 	selectableGroups?: boolean;
 }
-export default class GroupMultiSelectPrompt<T extends { value: any }> extends Prompt {
+export default class GroupMultiSelectPrompt<T extends { value: any }> extends Prompt<T['value'][]> {
 	options: (T & { group: string | boolean })[];
 	cursor = 0;
 	#selectableGroups: boolean;
@@ -19,11 +19,18 @@ export default class GroupMultiSelectPrompt<T extends { value: any }> extends Pr
 
 	isGroupSelected(group: string) {
 		const items = this.getGroupItems(group);
-		return items.every((i) => this.value.includes(i.value));
+		const value = this.value;
+		if (value === undefined) {
+			return false;
+		}
+		return items.every((i) => value.includes(i.value));
 	}
 
 	private toggleValue() {
 		const item = this.options[this.cursor];
+		if (this.value === undefined) {
+			this.value = [];
+		}
 		if (item.group === true) {
 			const group = item.value;
 			const groupedItems = this.getGroupItems(group);

--- a/packages/core/src/prompts/multi-select.ts
+++ b/packages/core/src/prompts/multi-select.ts
@@ -1,6 +1,7 @@
 import Prompt, { type PromptOptions } from './prompt.js';
 
-interface MultiSelectOptions<T extends { value: any }> extends PromptOptions<T['value'][], MultiSelectPrompt<T>> {
+interface MultiSelectOptions<T extends { value: any }>
+	extends PromptOptions<T['value'][], MultiSelectPrompt<T>> {
 	options: T[];
 	initialValues?: T['value'][];
 	required?: boolean;
@@ -15,8 +16,7 @@ export default class MultiSelectPrompt<T extends { value: any }> extends Prompt<
 	}
 
 	private toggleAll() {
-		const allSelected = this.value !== undefined &&
-			this.value.length === this.options.length;
+		const allSelected = this.value !== undefined && this.value.length === this.options.length;
 		this.value = allSelected ? [] : this.options.map((v) => v.value);
 	}
 

--- a/packages/core/src/prompts/multi-select.ts
+++ b/packages/core/src/prompts/multi-select.ts
@@ -1,28 +1,32 @@
 import Prompt, { type PromptOptions } from './prompt.js';
 
-interface MultiSelectOptions<T extends { value: any }> extends PromptOptions<MultiSelectPrompt<T>> {
+interface MultiSelectOptions<T extends { value: any }> extends PromptOptions<T['value'][], MultiSelectPrompt<T>> {
 	options: T[];
 	initialValues?: T['value'][];
 	required?: boolean;
 	cursorAt?: T['value'];
 }
-export default class MultiSelectPrompt<T extends { value: any }> extends Prompt {
+export default class MultiSelectPrompt<T extends { value: any }> extends Prompt<T['value'][]> {
 	options: T[];
 	cursor = 0;
 
-	private get _value() {
+	private get _value(): T['value'] {
 		return this.options[this.cursor].value;
 	}
 
 	private toggleAll() {
-		const allSelected = this.value.length === this.options.length;
+		const allSelected = this.value !== undefined &&
+			this.value.length === this.options.length;
 		this.value = allSelected ? [] : this.options.map((v) => v.value);
 	}
 
 	private toggleValue() {
+		if (this.value === undefined) {
+			this.value = [];
+		}
 		const selected = this.value.includes(this._value);
 		this.value = selected
-			? this.value.filter((value: T['value']) => value !== this._value)
+			? this.value.filter((value) => value !== this._value)
 			: [...this.value, this._value];
 	}
 

--- a/packages/core/src/prompts/password.ts
+++ b/packages/core/src/prompts/password.ts
@@ -1,27 +1,28 @@
 import color from 'picocolors';
 import Prompt, { type PromptOptions } from './prompt.js';
 
-interface PasswordOptions extends PromptOptions<PasswordPrompt> {
+interface PasswordOptions extends PromptOptions<string, PasswordPrompt> {
 	mask?: string;
 }
-export default class PasswordPrompt extends Prompt {
+export default class PasswordPrompt extends Prompt<string> {
 	private _mask = '•';
 	get cursor() {
 		return this._cursor;
 	}
 	get masked() {
-		return this.value?.replaceAll(/./g, this._mask) ?? '';
+		return this.userInput.replaceAll(/./g, this._mask);
 	}
-	get valueWithCursor() {
+	get userInputWithCursor() {
 		if (this.state === 'submit' || this.state === 'cancel') {
 			return this.masked;
 		}
-		const value = this.value ?? '';
-		if (this.cursor >= value.length) {
+		const userInput = this.userInput;
+		if (this.cursor >= userInput.length) {
 			return `${this.masked}${color.inverse(color.hidden('_'))}`;
 		}
-		const s1 = this.masked.slice(0, this.cursor);
-		const s2 = this.masked.slice(this.cursor);
+		const masked = this.masked;
+		const s1 = masked.slice(0, this.cursor);
+		const s2 = masked.slice(this.cursor);
 		return `${s1}${color.inverse(s2[0])}${s2.slice(1)}`;
 	}
 	constructor({ mask, ...opts }: PasswordOptions) {

--- a/packages/core/src/prompts/password.ts
+++ b/packages/core/src/prompts/password.ts
@@ -28,5 +28,8 @@ export default class PasswordPrompt extends Prompt<string> {
 	constructor({ mask, ...opts }: PasswordOptions) {
 		super(opts);
 		this._mask = mask ?? '•';
+		this.on('userInput', (input) => {
+			this._setValue(input);
+		});
 	}
 }

--- a/packages/core/src/prompts/prompt.ts
+++ b/packages/core/src/prompts/prompt.ts
@@ -36,7 +36,7 @@ export default class Prompt<TValue> {
 	public state: ClackState = 'initial';
 	public error = '';
 	public value: TValue | undefined;
-	public userInput: string = '';
+	public userInput = '';
 
 	constructor(options: PromptOptions<TValue, Prompt<TValue>>, trackValue = true) {
 		const { input = stdin, output = stdout, render, signal, ...opts } = options;
@@ -96,7 +96,10 @@ export default class Prompt<TValue> {
 	 * @param event - The event name
 	 * @param data - The data to pass to the callback
 	 */
-	public emit<T extends keyof ClackEvents<TValue>>(event: T, ...data: Parameters<ClackEvents<TValue>[T]>) {
+	public emit<T extends keyof ClackEvents<TValue>>(
+		event: T,
+		...data: Parameters<ClackEvents<TValue>[T]>
+	) {
 		const cbs = this._subscribers.get(event) ?? [];
 		const cleanup: (() => void)[] = [];
 
@@ -144,24 +147,6 @@ export default class Prompt<TValue> {
 
 			this.emit('beforePrompt');
 
-			if (this.opts.initialValue !== undefined) {
-				// TODO: this will go in the bin if we figure out the TODO in
-				// text prompt (L29)
-				if (this._track) {
-					this.rl.write(this.opts.initialValue);
-				}
-				this._setValue(this.opts.initialValue);
-
-				// Validate initial value if validator exists
-				if (this.opts.validate) {
-					const problem = this.opts.validate(this.value);
-					if (problem) {
-						this.error = problem instanceof Error ? problem.message : problem;
-						this.state = 'error';
-					}
-				}
-			}
-
 			this.input.on('keypress', this.onKeypress);
 			setRawMode(this.input, true);
 			this.output.on('resize', this.render);
@@ -197,6 +182,7 @@ export default class Prompt<TValue> {
 		this.emit('userInput', this.userInput);
 		if (write && this._track && this.rl) {
 			this.rl.write(this.userInput);
+			this._cursor = this.rl.cursor;
 		}
 	}
 

--- a/packages/core/src/prompts/select-key.ts
+++ b/packages/core/src/prompts/select-key.ts
@@ -1,6 +1,7 @@
 import Prompt, { type PromptOptions } from './prompt.js';
 
-interface SelectKeyOptions<T extends { value: any }> extends PromptOptions<T['value'], SelectKeyPrompt<T>> {
+interface SelectKeyOptions<T extends { value: any }>
+	extends PromptOptions<T['value'], SelectKeyPrompt<T>> {
 	options: T[];
 }
 export default class SelectKeyPrompt<T extends { value: any }> extends Prompt<T['value']> {

--- a/packages/core/src/prompts/select-key.ts
+++ b/packages/core/src/prompts/select-key.ts
@@ -1,9 +1,9 @@
 import Prompt, { type PromptOptions } from './prompt.js';
 
-interface SelectKeyOptions<T extends { value: any }> extends PromptOptions<SelectKeyPrompt<T>> {
+interface SelectKeyOptions<T extends { value: any }> extends PromptOptions<T['value'], SelectKeyPrompt<T>> {
 	options: T[];
 }
-export default class SelectKeyPrompt<T extends { value: any }> extends Prompt {
+export default class SelectKeyPrompt<T extends { value: any }> extends Prompt<T['value']> {
 	options: T[];
 	cursor = 0;
 

--- a/packages/core/src/prompts/select-key.ts
+++ b/packages/core/src/prompts/select-key.ts
@@ -1,10 +1,10 @@
 import Prompt, { type PromptOptions } from './prompt.js';
 
-interface SelectKeyOptions<T extends { value: any }>
+interface SelectKeyOptions<T extends { value: string }>
 	extends PromptOptions<T['value'], SelectKeyPrompt<T>> {
 	options: T[];
 }
-export default class SelectKeyPrompt<T extends { value: any }> extends Prompt<T['value']> {
+export default class SelectKeyPrompt<T extends { value: string }> extends Prompt<T['value']> {
 	options: T[];
 	cursor = 0;
 
@@ -16,7 +16,7 @@ export default class SelectKeyPrompt<T extends { value: any }> extends Prompt<T[
 		this.cursor = Math.max(keys.indexOf(opts.initialValue), 0);
 
 		this.on('key', (key) => {
-			if (!keys.includes(key)) return;
+			if (!key || !keys.includes(key)) return;
 			const value = this.options.find(({ value: [initial] }) => initial?.toLowerCase() === key);
 			if (value) {
 				this.value = value.value;

--- a/packages/core/src/prompts/select.ts
+++ b/packages/core/src/prompts/select.ts
@@ -1,6 +1,7 @@
 import Prompt, { type PromptOptions } from './prompt.js';
 
-interface SelectOptions<T extends { value: any }> extends PromptOptions<T['value'], SelectPrompt<T>> {
+interface SelectOptions<T extends { value: any }>
+	extends PromptOptions<T['value'], SelectPrompt<T>> {
 	options: T[];
 	initialValue?: T['value'];
 }

--- a/packages/core/src/prompts/select.ts
+++ b/packages/core/src/prompts/select.ts
@@ -1,19 +1,19 @@
 import Prompt, { type PromptOptions } from './prompt.js';
 
-interface SelectOptions<T extends { value: any }> extends PromptOptions<SelectPrompt<T>> {
+interface SelectOptions<T extends { value: any }> extends PromptOptions<T['value'], SelectPrompt<T>> {
 	options: T[];
 	initialValue?: T['value'];
 }
-export default class SelectPrompt<T extends { value: any }> extends Prompt {
+export default class SelectPrompt<T extends { value: any }> extends Prompt<T['value']> {
 	options: T[];
 	cursor = 0;
 
-	private get _value() {
+	private get _selectedValue() {
 		return this.options[this.cursor];
 	}
 
 	private changeValue() {
-		this.value = this._value.value;
+		this.value = this._selectedValue.value;
 	}
 
 	constructor(opts: SelectOptions<T>) {

--- a/packages/core/src/prompts/suggestion.ts
+++ b/packages/core/src/prompts/suggestion.ts
@@ -1,14 +1,12 @@
-import color from 'picocolors';
 import type { ValueWithCursorPart } from '../types.js';
 import Prompt, { type PromptOptions } from './prompt.js';
 
-interface SuggestionOptions extends PromptOptions<SuggestionPrompt> {
+interface SuggestionOptions extends PromptOptions<string, SuggestionPrompt> {
 	suggest: (value: string) => Array<string>;
 	initialValue: string;
 }
 
-export default class SuggestionPrompt extends Prompt {
-	value: string;
+export default class SuggestionPrompt extends Prompt<string> {
 	protected suggest: (value: string) => Array<string>;
 	private selectionIndex = 0;
 	private nextItems: Array<string> = [];
@@ -36,9 +34,9 @@ export default class SuggestionPrompt extends Prompt {
 					break;
 			}
 		});
-		this.on('key', (key, info) => {
+		this.on('key', (_key, info) => {
 			if (info.name === 'tab' && this.nextItems.length > 0) {
-				const delta = this.nextItems[this.selectionIndex].substring(this.value.length);
+				const delta = this.nextItems[this.selectionIndex].substring(this.userInput.length);
 				this.value = this.nextItems[this.selectionIndex];
 				this.rl?.write(delta);
 				this._cursor = this.value.length;
@@ -55,16 +53,16 @@ export default class SuggestionPrompt extends Prompt {
 		const result: Array<ValueWithCursorPart> = [];
 		if (this._cursor > 0) {
 			result.push({
-				text: this.value.substring(0, this._cursor),
+				text: this.userInput.substring(0, this._cursor),
 				type: 'value',
 			});
 		}
-		if (this._cursor < this.value.length) {
+		if (this._cursor < this.userInput.length) {
 			result.push({
-				text: this.value.substring(this._cursor, this._cursor + 1),
+				text: this.userInput.substring(this._cursor, this._cursor + 1),
 				type: 'cursor_on_value',
 			});
-			const left = this.value.substring(this._cursor + 1);
+			const left = this.userInput.substring(this._cursor + 1);
 			if (left.length > 0) {
 				result.push({
 					text: left,
@@ -100,12 +98,12 @@ export default class SuggestionPrompt extends Prompt {
 	}
 
 	get suggestion(): string {
-		return this.nextItems[this.selectionIndex]?.substring(this.value.length) ?? '';
+		return this.nextItems[this.selectionIndex]?.substring(this.userInput.length) ?? '';
 	}
 
 	private getNextItems(): void {
-		this.nextItems = this.suggest(this.value).filter((item) => {
-			return item.startsWith(this.value) && item !== this.value;
+		this.nextItems = this.suggest(this.userInput).filter((item) => {
+			return item.startsWith(this.userInput) && item !== this.value;
 		});
 		if (this.selectionIndex > this.nextItems.length) {
 			this.selectionIndex = 0;

--- a/packages/core/src/prompts/text.ts
+++ b/packages/core/src/prompts/text.ts
@@ -25,11 +25,13 @@ export default class TextPrompt extends Prompt<string> {
 	constructor(opts: TextOptions) {
 		super(opts);
 
-		// TODO: you were trying to move the logic to set the initial value
-		// as the user input into each individual prompt
-		// figure it out future james!
 		this.on('beforePrompt', () => {
-			this._setUserInput(this.value, true);
+			if (opts.initialValue !== undefined) {
+				this._setUserInput(opts.initialValue, true);
+			}
+		});
+		this.on('userInput', (input) => {
+			this._setValue(input);
 		});
 		this.on('finalize', () => {
 			if (!this.value) {

--- a/packages/core/src/prompts/text.ts
+++ b/packages/core/src/prompts/text.ts
@@ -1,22 +1,22 @@
 import color from 'picocolors';
 import Prompt, { type PromptOptions } from './prompt.js';
 
-interface TextOptions extends PromptOptions<TextPrompt> {
+interface TextOptions extends PromptOptions<string, TextPrompt> {
 	placeholder?: string;
 	defaultValue?: string;
 }
 
-export default class TextPrompt extends Prompt {
-	get valueWithCursor() {
+export default class TextPrompt extends Prompt<string> {
+	get userInputWithCursor() {
 		if (this.state === 'submit') {
-			return this.value;
+			return this.userInput;
 		}
-		const value = this.value ?? '';
-		if (this.cursor >= value.length) {
-			return `${this.value}█`;
+		const userInput = this.userInput;
+		if (this.cursor >= userInput.length) {
+			return `${this.userInput}█`;
 		}
-		const s1 = value.slice(0, this.cursor);
-		const [s2, ...s3] = value.slice(this.cursor);
+		const s1 = userInput.slice(0, this.cursor);
+		const [s2, ...s3] = userInput.slice(this.cursor);
 		return `${s1}${color.inverse(s2)}${s3.join('')}`;
 	}
 	get cursor() {
@@ -25,6 +25,12 @@ export default class TextPrompt extends Prompt {
 	constructor(opts: TextOptions) {
 		super(opts);
 
+		// TODO: you were trying to move the logic to set the initial value
+		// as the user input into each individual prompt
+		// figure it out future james!
+		this.on('beforePrompt', () => {
+			this._setUserInput(this.value, true);
+		});
 		this.on('finalize', () => {
 			if (!this.value) {
 				this.value = opts.defaultValue;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -9,7 +9,7 @@ export type ClackState = 'initial' | 'active' | 'cancel' | 'submit' | 'error';
 /**
  * Typed event emitter for clack
  */
-export interface ClackEvents {
+export interface ClackEvents<TValue> {
 	initial: (value?: any) => void;
 	active: (value?: any) => void;
 	cancel: (value?: any) => void;
@@ -17,9 +17,11 @@ export interface ClackEvents {
 	error: (value?: any) => void;
 	cursor: (key?: Action) => void;
 	key: (key: string | undefined, info: Key) => void;
-	value: (value?: string) => void;
+	value: (value?: TValue) => void;
+	userInput: (value: string) => void;
 	confirm: (value?: boolean) => void;
 	finalize: () => void;
+	beforePrompt: () => void;
 }
 
 /**

--- a/packages/core/test/prompts/autocomplete.test.ts
+++ b/packages/core/test/prompts/autocomplete.test.ts
@@ -132,7 +132,7 @@ describe('AutocompletePrompt', () => {
 		expect(instance.filteredOptions.length).to.equal(testOptions.length);
 
 		// Simulate typing 'a' by emitting value event
-		instance.emit('value', 'a');
+		input.emit('keypress', 'a', { name: 'a' });
 
 		// Check that filtered options are updated to include options with 'a'
 		expect(instance.filteredOptions.length).to.be.lessThan(testOptions.length);
@@ -150,14 +150,17 @@ describe('AutocompletePrompt', () => {
 			options: testOptions,
 		});
 
-		instance.emit('value', 'ap');
+		instance.prompt();
+
+		input.emit('keypress', 'a', { name: 'a' });
+		input.emit('keypress', 'p', { name: 'p' });
 
 		expect(instance.filteredOptions).toEqual([
 			{ value: 'apple', label: 'Apple' },
 			{ value: 'grape', label: 'Grape' },
 		]);
 
-		instance.emit('value', 'z');
+		input.emit('keypress', 'z', { name: 'z' });
 
 		expect(instance.filteredOptions).toEqual([]);
 	});

--- a/packages/core/test/prompts/password.test.ts
+++ b/packages/core/test/prompts/password.test.ts
@@ -41,7 +41,7 @@ describe('PasswordPrompt', () => {
 		});
 	});
 
-	describe('valueWithCursor', () => {
+	describe('userInputWithCursor', () => {
 		test('returns masked value on submit', () => {
 			const instance = new PasswordPrompt({
 				input,
@@ -54,7 +54,7 @@ describe('PasswordPrompt', () => {
 				input.emit('keypress', keys[i], { name: keys[i] });
 			}
 			input.emit('keypress', '', { name: 'return' });
-			expect(instance.valueWithCursor).to.equal('•••');
+			expect(instance.userInputWithCursor).to.equal('•••');
 		});
 
 		test('renders marker at end', () => {
@@ -65,7 +65,7 @@ describe('PasswordPrompt', () => {
 			});
 			instance.prompt();
 			input.emit('keypress', 'x', { name: 'x' });
-			expect(instance.valueWithCursor).to.equal(`•${color.inverse(color.hidden('_'))}`);
+			expect(instance.userInputWithCursor).to.equal(`•${color.inverse(color.hidden('_'))}`);
 		});
 
 		test('renders cursor inside value', () => {
@@ -80,7 +80,7 @@ describe('PasswordPrompt', () => {
 			input.emit('keypress', 'z', { name: 'z' });
 			input.emit('keypress', 'left', { name: 'left' });
 			input.emit('keypress', 'left', { name: 'left' });
-			expect(instance.valueWithCursor).to.equal(`•${color.inverse('•')}•`);
+			expect(instance.userInputWithCursor).to.equal(`•${color.inverse('•')}•`);
 		});
 
 		test('renders custom mask', () => {
@@ -92,7 +92,7 @@ describe('PasswordPrompt', () => {
 			});
 			instance.prompt();
 			input.emit('keypress', 'x', { name: 'x' });
-			expect(instance.valueWithCursor).to.equal(`X${color.inverse(color.hidden('_'))}`);
+			expect(instance.userInputWithCursor).to.equal(`X${color.inverse(color.hidden('_'))}`);
 		});
 	});
 });

--- a/packages/core/test/prompts/text.test.ts
+++ b/packages/core/test/prompts/text.test.ts
@@ -68,7 +68,7 @@ describe('TextPrompt', () => {
 		});
 	});
 
-	describe('valueWithCursor', () => {
+	describe('userInputWithCursor', () => {
 		test('returns value on submit', () => {
 			const instance = new TextPrompt({
 				input,
@@ -78,7 +78,7 @@ describe('TextPrompt', () => {
 			instance.prompt();
 			input.emit('keypress', 'x', { name: 'x' });
 			input.emit('keypress', '', { name: 'return' });
-			expect(instance.valueWithCursor).to.equal('x');
+			expect(instance.userInputWithCursor).to.equal('x');
 		});
 
 		test('highlights cursor position', () => {
@@ -93,7 +93,7 @@ describe('TextPrompt', () => {
 				input.emit('keypress', keys[i], { name: keys[i] });
 			}
 			input.emit('keypress', 'left', { name: 'left' });
-			expect(instance.valueWithCursor).to.equal(`fo${color.inverse('o')}`);
+			expect(instance.userInputWithCursor).to.equal(`fo${color.inverse('o')}`);
 		});
 
 		test('shows cursor at end if beyond value', () => {
@@ -108,7 +108,7 @@ describe('TextPrompt', () => {
 				input.emit('keypress', keys[i], { name: keys[i] });
 			}
 			input.emit('keypress', 'right', { name: 'right' });
-			expect(instance.valueWithCursor).to.equal('foo█');
+			expect(instance.userInputWithCursor).to.equal('foo█');
 		});
 
 		test('does not use placeholder as value when pressing enter', async () => {

--- a/packages/prompts/src/autocomplete.ts
+++ b/packages/prompts/src/autocomplete.ts
@@ -77,7 +77,7 @@ export const autocomplete = <Value>(opts: AutocompleteOptions<Value>) => {
 		render() {
 			// Title and message display
 			const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;
-			const valueAsString = String(this.value ?? '');
+			const userInput = this.userInput;
 
 			// Handle different states
 			switch (this.state) {
@@ -89,12 +89,12 @@ export const autocomplete = <Value>(opts: AutocompleteOptions<Value>) => {
 				}
 
 				case 'cancel': {
-					return `${title}${color.gray(S_BAR)}  ${color.strikethrough(color.dim(this.value ?? ''))}`;
+					return `${title}${color.gray(S_BAR)}  ${color.strikethrough(color.dim(userInput))}`;
 				}
 
 				default: {
 					// Display cursor position - show plain text in navigation mode
-					const searchText = this.isNavigating ? color.dim(valueAsString) : this.valueWithCursor;
+					const searchText = this.isNavigating ? color.dim(userInput) : this.userInputWithCursor;
 
 					// Show match count if filtered
 					const matches =
@@ -135,7 +135,7 @@ export const autocomplete = <Value>(opts: AutocompleteOptions<Value>) => {
 
 					// No matches message
 					const noResults =
-						this.filteredOptions.length === 0 && valueAsString
+						this.filteredOptions.length === 0 && userInput
 							? [`${color.cyan(S_BAR)}  ${color.yellow('No matches found')}`]
 							: [];
 
@@ -229,16 +229,12 @@ export const autocompleteMultiselect = <Value>(opts: AutocompleteMultiSelectOpti
 			const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;
 
 			// Selection counter
-			const counter =
-				this.selectedValues.length > 0
-					? color.cyan(` (${this.selectedValues.length} selected)`)
-					: '';
 			const value = String(this.value ?? '');
 
 			// Search input display
 			const searchText = this.isNavigating
 				? color.dim(value) // Just show plain text when in navigation mode
-				: this.valueWithCursor;
+				: this.userInputWithCursor;
 
 			const matches =
 				this.filteredOptions.length !== opts.options.length

--- a/packages/prompts/src/autocomplete.ts
+++ b/packages/prompts/src/autocomplete.ts
@@ -222,7 +222,7 @@ export const autocompleteMultiselect = <Value>(opts: AutocompleteMultiSelectOpti
 			const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;
 
 			// Selection counter
-			const userInput = this.userInput
+			const userInput = this.userInput;
 			const placeholder = opts.placeholder;
 			const showPlaceholder = userInput === '' && placeholder !== undefined;
 

--- a/packages/prompts/src/group-multi-select.ts
+++ b/packages/prompts/src/group-multi-select.ts
@@ -83,8 +83,8 @@ export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) =>
 		required: opts.required ?? true,
 		cursorAt: opts.cursorAt,
 		selectableGroups,
-		validate(selected: Value[]) {
-			if (this.required && selected.length === 0)
+		validate(selected: Value[] | undefined) {
+			if (this.required && (selected === undefined || selected.length === 0))
 				return `Please select at least one option.\n${color.reset(
 					color.dim(
 						`Press ${color.gray(color.bgWhite(color.inverse(' space ')))} to select, ${color.gray(
@@ -95,17 +95,18 @@ export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) =>
 		},
 		render() {
 			const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;
+			const value = this.value ?? [];
 
 			switch (this.state) {
 				case 'submit': {
 					return `${title}${color.gray(S_BAR)}  ${this.options
-						.filter(({ value }) => this.value.includes(value))
+						.filter(({ value: optionValue }) => value.includes(optionValue))
 						.map((option) => opt(option, 'submitted'))
 						.join(color.dim(', '))}`;
 				}
 				case 'cancel': {
 					const label = this.options
-						.filter(({ value }) => this.value.includes(value))
+						.filter(({ value: optionValue }) => value.includes(optionValue))
 						.map((option) => opt(option, 'cancelled'))
 						.join(color.dim(', '));
 					return `${title}${color.gray(S_BAR)}  ${
@@ -122,7 +123,7 @@ export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) =>
 					return `${title}${color.yellow(S_BAR)}  ${this.options
 						.map((option, i, options) => {
 							const selected =
-								this.value.includes(option.value) ||
+								value.includes(option.value) ||
 								(option.group === true && this.isGroupSelected(`${option.value}`));
 							const active = i === this.cursor;
 							const groupActive =
@@ -146,7 +147,7 @@ export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) =>
 					return `${title}${color.cyan(S_BAR)}  ${this.options
 						.map((option, i, options) => {
 							const selected =
-								this.value.includes(option.value) ||
+								value.includes(option.value) ||
 								(option.group === true && this.isGroupSelected(`${option.value}`));
 							const active = i === this.cursor;
 							const groupActive =

--- a/packages/prompts/src/multi-select.ts
+++ b/packages/prompts/src/multi-select.ts
@@ -57,8 +57,8 @@ export const multiselect = <Value>(opts: MultiSelectOptions<Value>) => {
 		initialValues: opts.initialValues,
 		required: opts.required ?? true,
 		cursorAt: opts.cursorAt,
-		validate(selected: Value[]) {
-			if (this.required && selected.length === 0)
+		validate(selected: Value[] | undefined) {
+			if (this.required && (selected === undefined || selected.length === 0))
 				return `Please select at least one option.\n${color.reset(
 					color.dim(
 						`Press ${color.gray(color.bgWhite(color.inverse(' space ')))} to select, ${color.gray(
@@ -69,9 +69,10 @@ export const multiselect = <Value>(opts: MultiSelectOptions<Value>) => {
 		},
 		render() {
 			const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;
+			const value = this.value ?? [];
 
 			const styleOption = (option: Option<Value>, active: boolean) => {
-				const selected = this.value.includes(option.value);
+				const selected = value.includes(option.value);
 				if (active && selected) {
 					return opt(option, 'active-selected');
 				}
@@ -85,14 +86,14 @@ export const multiselect = <Value>(opts: MultiSelectOptions<Value>) => {
 				case 'submit': {
 					return `${title}${color.gray(S_BAR)}  ${
 						this.options
-							.filter(({ value }) => this.value.includes(value))
+							.filter(({ value: optionValue }) => value.includes(optionValue))
 							.map((option) => opt(option, 'submitted'))
 							.join(color.dim(', ')) || color.dim('none')
 					}`;
 				}
 				case 'cancel': {
 					const label = this.options
-						.filter(({ value }) => this.value.includes(value))
+						.filter(({ value: optionValue }) => value.includes(optionValue))
 						.map((option) => opt(option, 'cancelled'))
 						.join(color.dim(', '));
 					return `${title}${color.gray(S_BAR)}  ${

--- a/packages/prompts/src/password.ts
+++ b/packages/prompts/src/password.ts
@@ -5,7 +5,7 @@ import { type CommonOptions, S_BAR, S_BAR_END, S_PASSWORD_MASK, symbol } from '.
 export interface PasswordOptions extends CommonOptions {
 	message: string;
 	mask?: string;
-	validate?: (value: string) => string | Error | undefined;
+	validate?: (value: string|undefined) => string | Error | undefined;
 }
 export const password = (opts: PasswordOptions) => {
 	return new PasswordPrompt({
@@ -15,7 +15,7 @@ export const password = (opts: PasswordOptions) => {
 		output: opts.output,
 		render() {
 			const title = `${color.gray(S_BAR)}\n${symbol(this.state)}  ${opts.message}\n`;
-			const value = this.valueWithCursor;
+			const userInput = this.userInputWithCursor;
 			const masked = this.masked;
 
 			switch (this.state) {
@@ -26,11 +26,11 @@ export const password = (opts: PasswordOptions) => {
 				case 'submit':
 					return `${title}${color.gray(S_BAR)}  ${color.dim(masked)}`;
 				case 'cancel':
-					return `${title}${color.gray(S_BAR)}  ${color.strikethrough(color.dim(masked ?? ''))}${
+					return `${title}${color.gray(S_BAR)}  ${color.strikethrough(color.dim(masked))}${
 						masked ? `\n${color.gray(S_BAR)}` : ''
 					}`;
 				default:
-					return `${title}${color.cyan(S_BAR)}  ${value}\n${color.cyan(S_BAR_END)}\n`;
+					return `${title}${color.cyan(S_BAR)}  ${userInput}\n${color.cyan(S_BAR_END)}\n`;
 			}
 		},
 	}).prompt() as Promise<string | symbol>;

--- a/packages/prompts/src/password.ts
+++ b/packages/prompts/src/password.ts
@@ -5,7 +5,7 @@ import { type CommonOptions, S_BAR, S_BAR_END, S_PASSWORD_MASK, symbol } from '.
 export interface PasswordOptions extends CommonOptions {
 	message: string;
 	mask?: string;
-	validate?: (value: string|undefined) => string | Error | undefined;
+	validate?: (value: string | undefined) => string | Error | undefined;
 }
 export const password = (opts: PasswordOptions) => {
 	return new PasswordPrompt({

--- a/packages/prompts/src/path.ts
+++ b/packages/prompts/src/path.ts
@@ -1,7 +1,7 @@
 import { existsSync, lstatSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { dirname } from 'knip/dist/util/path.js';
-import { type CommonOptions, S_BAR, S_BAR_END, symbol } from './common.js';
+import { type CommonOptions } from './common.js';
 import { suggestion } from './suggestion.js';
 
 export interface PathOptions extends CommonOptions {
@@ -9,7 +9,7 @@ export interface PathOptions extends CommonOptions {
 	directory?: boolean;
 	initialValue?: string;
 	message: string;
-	validate?: (value: string) => string | Error | undefined;
+	validate?: (value: string | undefined) => string | Error | undefined;
 }
 
 export const path = (opts: PathOptions) => {

--- a/packages/prompts/src/path.ts
+++ b/packages/prompts/src/path.ts
@@ -1,7 +1,7 @@
 import { existsSync, lstatSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { dirname } from 'knip/dist/util/path.js';
-import { type CommonOptions } from './common.js';
+import type { CommonOptions } from './common.js';
 import { suggestion } from './suggestion.js';
 
 export interface PathOptions extends CommonOptions {

--- a/packages/prompts/src/suggestion.ts
+++ b/packages/prompts/src/suggestion.ts
@@ -5,7 +5,7 @@ import { type CommonOptions, S_BAR, S_BAR_END, symbol } from './common.js';
 export interface SuggestionOptions extends CommonOptions {
 	initialValue?: string;
 	message: string;
-	validate?: (value: string) => string | Error | undefined;
+	validate?: (value: string | undefined) => string | Error | undefined;
 	suggest: (value: string) => Array<string>;
 }
 

--- a/packages/prompts/src/text.ts
+++ b/packages/prompts/src/text.ts
@@ -7,7 +7,7 @@ export interface TextOptions extends CommonOptions {
 	placeholder?: string;
 	defaultValue?: string;
 	initialValue?: string;
-	validate?: (value: string) => string | Error | undefined;
+	validate?: (value: string | undefined) => string | Error | undefined;
 }
 
 export const text = (opts: TextOptions) => {
@@ -23,7 +23,7 @@ export const text = (opts: TextOptions) => {
 			const placeholder = opts.placeholder
 				? color.inverse(opts.placeholder[0]) + color.dim(opts.placeholder.slice(1))
 				: color.inverse(color.hidden('_'));
-			const value = !this.value ? placeholder : this.valueWithCursor;
+			const value = !this.userInput ? placeholder : this.userInputWithCursor;
 
 			switch (this.state) {
 				case 'error':
@@ -31,13 +31,13 @@ export const text = (opts: TextOptions) => {
 						S_BAR_END
 					)}  ${color.yellow(this.error)}\n`;
 				case 'submit': {
-					const displayValue = typeof this.value === 'undefined' ? '' : this.value;
+					const displayValue = this.userInput === undefined ? '' : this.userInput;
 					return `${title}${color.gray(S_BAR)}  ${color.dim(displayValue)}`;
 				}
 				case 'cancel':
 					return `${title}${color.gray(S_BAR)}  ${color.strikethrough(
-						color.dim(this.value ?? '')
-					)}${this.value?.trim() ? `\n${color.gray(S_BAR)}` : ''}`;
+						color.dim(this.userInput ?? '')
+					)}${this.userInput?.trim() ? `\n${color.gray(S_BAR)}` : ''}`;
 				default:
 					return `${title}${color.cyan(S_BAR)}  ${value}\n${color.cyan(S_BAR_END)}\n`;
 			}

--- a/packages/prompts/src/text.ts
+++ b/packages/prompts/src/text.ts
@@ -23,23 +23,23 @@ export const text = (opts: TextOptions) => {
 			const placeholder = opts.placeholder
 				? color.inverse(opts.placeholder[0]) + color.dim(opts.placeholder.slice(1))
 				: color.inverse(color.hidden('_'));
-			const value = !this.userInput ? placeholder : this.userInputWithCursor;
+			const userInput = !this.userInput ? placeholder : this.userInputWithCursor;
+			const value = this.value ?? '';
 
 			switch (this.state) {
 				case 'error':
-					return `${title.trim()}\n${color.yellow(S_BAR)}  ${value}\n${color.yellow(
+					return `${title.trim()}\n${color.yellow(S_BAR)}  ${userInput}\n${color.yellow(
 						S_BAR_END
 					)}  ${color.yellow(this.error)}\n`;
 				case 'submit': {
-					const displayValue = this.userInput === undefined ? '' : this.userInput;
-					return `${title}${color.gray(S_BAR)}  ${color.dim(displayValue)}`;
+					return `${title}${color.gray(S_BAR)}  ${color.dim(value)}`;
 				}
 				case 'cancel':
 					return `${title}${color.gray(S_BAR)}  ${color.strikethrough(
-						color.dim(this.userInput ?? '')
-					)}${this.userInput?.trim() ? `\n${color.gray(S_BAR)}` : ''}`;
+						color.dim(value)
+					)}${value.trim() ? `\n${color.gray(S_BAR)}` : ''}`;
 				default:
-					return `${title}${color.cyan(S_BAR)}  ${value}\n${color.cyan(S_BAR_END)}\n`;
+					return `${title}${color.cyan(S_BAR)}  ${userInput}\n${color.cyan(S_BAR_END)}\n`;
 			}
 		},
 	}).prompt() as Promise<string | symbol>;

--- a/packages/prompts/test/__snapshots__/path.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/path.test.ts.snap
@@ -143,21 +143,17 @@ exports[`text (isCI = false) > renders submitted value 1`] = `
 
 exports[`text (isCI = false) > validation errors render and clear (using Error) 1`] = `
 [
-  "<cursor.backward count=999>",
-  "",
-  "<erase.down>",
+  "<cursor.hide>",
   "[90m│[39m
-[33m▲[39m  foo
-[33m│[39m  /tmp/[7m[90mf[39m[27m[90moo[39m
-[33m└[39m  [33mshould be /tmp/bar[39m
-",
-  "<cursor.backward count=999><cursor.up count=4>",
-  "<cursor.down count=1>",
-  "<erase.down>",
-  "[36m◆[39m  foo
-[36m│[39m  /tmp/b[7m [27m
+[36m◆[39m  foo
+[36m│[39m  /tmp/[7m[90mf[39m[27m[90moo[39m
 [36m└[39m
 ",
+  "<cursor.backward count=999><cursor.up count=4>",
+  "<cursor.down count=2>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  /tmp/b[7m [27m",
+  "<cursor.down count=2>",
   "<cursor.backward count=999><cursor.up count=4>",
   "<cursor.down count=1>",
   "<erase.down>",
@@ -190,21 +186,17 @@ exports[`text (isCI = false) > validation errors render and clear (using Error) 
 
 exports[`text (isCI = false) > validation errors render and clear 1`] = `
 [
-  "<cursor.backward count=999>",
-  "",
-  "<erase.down>",
+  "<cursor.hide>",
   "[90m│[39m
-[33m▲[39m  foo
-[33m│[39m  /tmp/[7m[90mf[39m[27m[90moo[39m
-[33m└[39m  [33mshould be /tmp/bar[39m
-",
-  "<cursor.backward count=999><cursor.up count=4>",
-  "<cursor.down count=1>",
-  "<erase.down>",
-  "[36m◆[39m  foo
-[36m│[39m  /tmp/b[7m [27m
+[36m◆[39m  foo
+[36m│[39m  /tmp/[7m[90mf[39m[27m[90moo[39m
 [36m└[39m
 ",
+  "<cursor.backward count=999><cursor.up count=4>",
+  "<cursor.down count=2>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  /tmp/b[7m [27m",
+  "<cursor.down count=2>",
   "<cursor.backward count=999><cursor.up count=4>",
   "<cursor.down count=1>",
   "<erase.down>",
@@ -378,21 +370,17 @@ exports[`text (isCI = true) > renders submitted value 1`] = `
 
 exports[`text (isCI = true) > validation errors render and clear (using Error) 1`] = `
 [
-  "<cursor.backward count=999>",
-  "",
-  "<erase.down>",
+  "<cursor.hide>",
   "[90m│[39m
-[33m▲[39m  foo
-[33m│[39m  /tmp/[7m[90mf[39m[27m[90moo[39m
-[33m└[39m  [33mshould be /tmp/bar[39m
-",
-  "<cursor.backward count=999><cursor.up count=4>",
-  "<cursor.down count=1>",
-  "<erase.down>",
-  "[36m◆[39m  foo
-[36m│[39m  /tmp/b[7m [27m
+[36m◆[39m  foo
+[36m│[39m  /tmp/[7m[90mf[39m[27m[90moo[39m
 [36m└[39m
 ",
+  "<cursor.backward count=999><cursor.up count=4>",
+  "<cursor.down count=2>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  /tmp/b[7m [27m",
+  "<cursor.down count=2>",
   "<cursor.backward count=999><cursor.up count=4>",
   "<cursor.down count=1>",
   "<erase.down>",
@@ -425,21 +413,17 @@ exports[`text (isCI = true) > validation errors render and clear (using Error) 1
 
 exports[`text (isCI = true) > validation errors render and clear 1`] = `
 [
-  "<cursor.backward count=999>",
-  "",
-  "<erase.down>",
+  "<cursor.hide>",
   "[90m│[39m
-[33m▲[39m  foo
-[33m│[39m  /tmp/[7m[90mf[39m[27m[90moo[39m
-[33m└[39m  [33mshould be /tmp/bar[39m
-",
-  "<cursor.backward count=999><cursor.up count=4>",
-  "<cursor.down count=1>",
-  "<erase.down>",
-  "[36m◆[39m  foo
-[36m│[39m  /tmp/b[7m [27m
+[36m◆[39m  foo
+[36m│[39m  /tmp/[7m[90mf[39m[27m[90moo[39m
 [36m└[39m
 ",
+  "<cursor.backward count=999><cursor.up count=4>",
+  "<cursor.down count=2>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  /tmp/b[7m [27m",
+  "<cursor.down count=2>",
   "<cursor.backward count=999><cursor.up count=4>",
   "<cursor.down count=1>",
   "<erase.down>",

--- a/packages/prompts/test/__snapshots__/suggestion.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/suggestion.test.ts.snap
@@ -142,21 +142,17 @@ exports[`text (isCI = false) > renders submitted value 1`] = `
 
 exports[`text (isCI = false) > validation errors render and clear (using Error) 1`] = `
 [
-  "<cursor.backward count=999>",
-  "",
-  "<erase.down>",
+  "<cursor.hide>",
   "[90m│[39m
-[33m▲[39m  foo
-[33m│[39m  [7m[90mx[39m[27m[90myz[39m
-[33m└[39m  [33mshould be xy[39m
-",
-  "<cursor.backward count=999><cursor.up count=4>",
-  "<cursor.down count=1>",
-  "<erase.down>",
-  "[36m◆[39m  foo
-[36m│[39m  x[7m[90my[39m[27m[90mz[39m
+[36m◆[39m  foo
+[36m│[39m  [7m[90mx[39m[27m[90myz[39m
 [36m└[39m
 ",
+  "<cursor.backward count=999><cursor.up count=4>",
+  "<cursor.down count=2>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  x[7m[90my[39m[27m[90mz[39m",
+  "<cursor.down count=2>",
   "<cursor.backward count=999><cursor.up count=4>",
   "<cursor.down count=1>",
   "<erase.down>",
@@ -184,21 +180,17 @@ exports[`text (isCI = false) > validation errors render and clear (using Error) 
 
 exports[`text (isCI = false) > validation errors render and clear 1`] = `
 [
-  "<cursor.backward count=999>",
-  "",
-  "<erase.down>",
+  "<cursor.hide>",
   "[90m│[39m
-[33m▲[39m  foo
-[33m│[39m  [7m[90mx[39m[27m[90myz[39m
-[33m└[39m  [33mshould be xy[39m
-",
-  "<cursor.backward count=999><cursor.up count=4>",
-  "<cursor.down count=1>",
-  "<erase.down>",
-  "[36m◆[39m  foo
-[36m│[39m  x[7m[90my[39m[27m[90mz[39m
+[36m◆[39m  foo
+[36m│[39m  [7m[90mx[39m[27m[90myz[39m
 [36m└[39m
 ",
+  "<cursor.backward count=999><cursor.up count=4>",
+  "<cursor.down count=2>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  x[7m[90my[39m[27m[90mz[39m",
+  "<cursor.down count=2>",
   "<cursor.backward count=999><cursor.up count=4>",
   "<cursor.down count=1>",
   "<erase.down>",
@@ -366,21 +358,17 @@ exports[`text (isCI = true) > renders submitted value 1`] = `
 
 exports[`text (isCI = true) > validation errors render and clear (using Error) 1`] = `
 [
-  "<cursor.backward count=999>",
-  "",
-  "<erase.down>",
+  "<cursor.hide>",
   "[90m│[39m
-[33m▲[39m  foo
-[33m│[39m  [7m[90mx[39m[27m[90myz[39m
-[33m└[39m  [33mshould be xy[39m
-",
-  "<cursor.backward count=999><cursor.up count=4>",
-  "<cursor.down count=1>",
-  "<erase.down>",
-  "[36m◆[39m  foo
-[36m│[39m  x[7m[90my[39m[27m[90mz[39m
+[36m◆[39m  foo
+[36m│[39m  [7m[90mx[39m[27m[90myz[39m
 [36m└[39m
 ",
+  "<cursor.backward count=999><cursor.up count=4>",
+  "<cursor.down count=2>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  x[7m[90my[39m[27m[90mz[39m",
+  "<cursor.down count=2>",
   "<cursor.backward count=999><cursor.up count=4>",
   "<cursor.down count=1>",
   "<erase.down>",
@@ -408,21 +396,17 @@ exports[`text (isCI = true) > validation errors render and clear (using Error) 1
 
 exports[`text (isCI = true) > validation errors render and clear 1`] = `
 [
-  "<cursor.backward count=999>",
-  "",
-  "<erase.down>",
+  "<cursor.hide>",
   "[90m│[39m
-[33m▲[39m  foo
-[33m│[39m  [7m[90mx[39m[27m[90myz[39m
-[33m└[39m  [33mshould be xy[39m
-",
-  "<cursor.backward count=999><cursor.up count=4>",
-  "<cursor.down count=1>",
-  "<erase.down>",
-  "[36m◆[39m  foo
-[36m│[39m  x[7m[90my[39m[27m[90mz[39m
+[36m◆[39m  foo
+[36m│[39m  [7m[90mx[39m[27m[90myz[39m
 [36m└[39m
 ",
+  "<cursor.backward count=999><cursor.up count=4>",
+  "<cursor.down count=2>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  x[7m[90my[39m[27m[90mz[39m",
+  "<cursor.down count=2>",
   "<cursor.backward count=999><cursor.up count=4>",
   "<cursor.down count=1>",
   "<erase.down>",

--- a/packages/prompts/test/path.test.ts
+++ b/packages/prompts/test/path.test.ts
@@ -1,4 +1,4 @@
-import { fs, vol } from 'memfs';
+import { vol } from 'memfs';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import * as prompts from '../src/index.js';
 import { MockReadable, MockWritable } from './test-utils.js';


### PR DESCRIPTION
Fixes #330 

Basically, this introduces a new `userInput` field and event to the core.

The difference is:
- `userInput` tracks what the user has typed in (if `track: true`)
- nothing changes `value` in the core anymore

This means it is the responsibility of each prompt to decide what to do with `value`. They can then call `this._setValue(value)` to set the value and trigger the `value` event.

### An example - text prompt

The text prompt wants to set the value to what the user has typed in. So we can simply listen for `userInput` and set `value` to whatever they have typed. Or we can wait for `finalize` and do it.

### A more complex example - auto complete

The auto complete prompt wants to take user input, but this isn't the value. The value should be the _completed value_.

To achieve this, we can set `value` only once someone selects an option.

This means the `value` is only ever `undefined` or a selected option.