### PR TITLE
chore: run CI against PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
-    types: [assigned, opened, synchronize, reopened]
-    branches:
-      - main
+  pull_request:
 
 # Automatically cancel in-progress actions on the same branch
 concurrency:


### PR DESCRIPTION
We run CI against _targets_ right now (`main`), rather than the PR itself. This change should mean we run CI against the PR branch.