### PR TITLE
chore(format): ignore package.json files

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -12,7 +12,7 @@
     "lineWidth": 100,
     "attributePosition": "auto",
     "bracketSpacing": true,
-    "ignore": [".github/workflows/**/*.yml", ".changeset/**/*.md", "**/pnpm-lock.yaml"]
+    "ignore": [".github/workflows/**/*.yml", ".changeset/**/*.md", "**/pnpm-lock.yaml", "**/package.json"]
   },
   "organizeImports": { "enabled": true },
   "linter": {


### PR DESCRIPTION
our format action would fight with changesets on `package.json` files. we should skip formatting `package.json` files until we figure out how to align the two tools.