### PR TITLE
feat: tasklog groups

### DIFF
--- a/.changeset/sharp-lemons-build.md
+++ b/.changeset/sharp-lemons-build.md
@@ -1,0 +1,5 @@
+---
+"@clack/prompts": minor
+---
+
+Using the `group` method, task logs can now have groups which themselves can have scrolling windows of logs.

--- a/packages/prompts/src/common.ts
+++ b/packages/prompts/src/common.ts
@@ -1,13 +1,13 @@
 import type { Readable, Writable } from 'node:stream';
+import { WriteStream } from 'node:tty';
 import type { State } from '@clack/core';
 import isUnicodeSupported from 'is-unicode-supported';
 import color from 'picocolors';
-import {WriteStream} from 'node:tty';
 
 export const unicode = isUnicodeSupported();
 export const isCI = (): boolean => process.env.CI === 'true';
 export const isTTY = (output: Writable): boolean => {
-	return (output instanceof WriteStream) && output.isTTY === true;
+	return output instanceof WriteStream && output.isTTY === true;
 };
 export const unicodeOr = (c: string, fallback: string) => (unicode ? c : fallback);
 export const S_STEP_ACTIVE = unicodeOr('◆', '*');

--- a/packages/prompts/src/common.ts
+++ b/packages/prompts/src/common.ts
@@ -1,5 +1,4 @@
 import type { Readable, Writable } from 'node:stream';
-import { WriteStream } from 'node:tty';
 import type { State } from '@clack/core';
 import isUnicodeSupported from 'is-unicode-supported';
 import color from 'picocolors';
@@ -7,7 +6,7 @@ import color from 'picocolors';
 export const unicode = isUnicodeSupported();
 export const isCI = (): boolean => process.env.CI === 'true';
 export const isTTY = (output: Writable): boolean => {
-	return output instanceof WriteStream && output.isTTY === true;
+	return (output as Writable & { isTTY?: boolean }).isTTY === true;
 };
 export const unicodeOr = (c: string, fallback: string) => (unicode ? c : fallback);
 export const S_STEP_ACTIVE = unicodeOr('◆', '*');

--- a/packages/prompts/src/common.ts
+++ b/packages/prompts/src/common.ts
@@ -2,9 +2,13 @@ import type { Readable, Writable } from 'node:stream';
 import type { State } from '@clack/core';
 import isUnicodeSupported from 'is-unicode-supported';
 import color from 'picocolors';
+import {WriteStream} from 'node:tty';
 
 export const unicode = isUnicodeSupported();
 export const isCI = (): boolean => process.env.CI === 'true';
+export const isTTY = (output: Writable): boolean => {
+	return (output instanceof WriteStream) && output.isTTY === true;
+};
 export const unicodeOr = (c: string, fallback: string) => (unicode ? c : fallback);
 export const S_STEP_ACTIVE = unicodeOr('◆', '*');
 export const S_STEP_CANCEL = unicodeOr('■', 'x');

--- a/packages/prompts/src/task-log.ts
+++ b/packages/prompts/src/task-log.ts
@@ -101,7 +101,7 @@ export const taskLog = (opts: TaskLogOptions) => {
 				output,
 				secondarySymbol,
 				symbol: secondarySymbol,
-				spacing: messageSpacing ?? spacing,
+				spacing: 0,
 			});
 		}
 		log.message(messages.split('\n').map(color.dim), {

--- a/packages/prompts/src/task-log.ts
+++ b/packages/prompts/src/task-log.ts
@@ -68,16 +68,21 @@ export const taskLog = (opts: TaskLogOptions) => {
 			lines += spacing + 2;
 		}
 
-		for (const { value } of buffers) {
-			if (value.length === 0) {
+		for (const buffer of buffers) {
+			const { value, result } = buffer;
+			const text = result?.message ?? value;
+
+			if (text.length === 0) {
 				continue;
 			}
-			const bufferHeight = value.split('\n').reduce((count, line) => {
+
+			const bufferHeight = text.split('\n').reduce((count, line) => {
 				if (line === '') {
 					return count + 1;
 				}
 				return count + Math.ceil((line.length + barSize) / columns);
 			}, 0);
+
 			lines += bufferHeight;
 		}
 
@@ -129,9 +134,9 @@ export const taskLog = (opts: TaskLogOptions) => {
 		for (const buffer of buffers) {
 			if (buffer.result) {
 				if (buffer.result.status === 'error') {
-					log.error(buffer.result.message, { output, secondarySymbol, spacing: 1 });
+					log.error(buffer.result.message, { output, secondarySymbol, spacing: 0 });
 				} else {
-					log.success(buffer.result.message, { output, secondarySymbol, spacing: 1 });
+					log.success(buffer.result.message, { output, secondarySymbol, spacing: 0 });
 				}
 			} else if (buffer.value !== '') {
 				printBuffer(buffer.value, 0);

--- a/packages/prompts/src/task-log.ts
+++ b/packages/prompts/src/task-log.ts
@@ -2,7 +2,13 @@ import type { Writable } from 'node:stream';
 import { getColumns } from '@clack/core';
 import color from 'picocolors';
 import { erase } from 'sisteransi';
-import { type CommonOptions, S_BAR, S_STEP_SUBMIT, isTTY as isTTYFn } from './common.js';
+import {
+	type CommonOptions,
+	S_BAR,
+	S_STEP_SUBMIT,
+	isCI as isCIFn,
+	isTTY as isTTYFn,
+} from './common.js';
 import { log } from './log.js';
 
 export interface TaskLogOptions extends CommonOptions {
@@ -40,7 +46,7 @@ export const taskLog = (opts: TaskLogOptions) => {
 	const spacing = opts.spacing ?? 1;
 	const barSize = 3;
 	const retainLog = opts.retainLog === true;
-	const isTTY = isTTYFn(output);
+	const isTTY = !isCIFn() && isTTYFn(output);
 
 	output.write(`${secondarySymbol}\n`);
 	output.write(`${color.green(S_STEP_SUBMIT)}  ${opts.title}\n`);

--- a/packages/prompts/src/task-log.ts
+++ b/packages/prompts/src/task-log.ts
@@ -78,8 +78,10 @@ export const taskLog = (opts: TaskLogOptions) => {
 				}
 				return count + Math.ceil((line.length + barSize) / columns);
 			}, 0);
-			lines += bufferHeight + 1;
+			lines += bufferHeight;
 		}
+
+		lines += 1;
 
 		output.write(erase.lines(lines));
 	};

--- a/packages/prompts/test/__snapshots__/task-log.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/task-log.test.ts.snap
@@ -382,6 +382,19 @@ exports[`taskLog (isCI = false) > group > can render multiple groups of equal si
 ]
 `;
 
+exports[`taskLog (isCI = false) > group > handles empty groups 1`] = `
+[
+  "[90m│[39m
+",
+  "[32m◇[39m  Some log
+",
+  "[90m│[39m
+",
+  "[32m◆[39m  Group success!
+",
+]
+`;
+
 exports[`taskLog (isCI = false) > group > renders error state 1`] = `
 [
   "[90m│[39m
@@ -1220,6 +1233,17 @@ exports[`taskLog (isCI = true) > group > can render multiple groups of equal siz
   "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
   "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
   "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+]
+`;
+
+exports[`taskLog (isCI = true) > group > handles empty groups 1`] = `
+[
+  "[90m│[39m
+",
+  "[32m◇[39m  Some log
+",
+  "[90m│[39m
+",
 ]
 `;
 

--- a/packages/prompts/test/__snapshots__/task-log.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/task-log.test.ts.snap
@@ -106,8 +106,6 @@ exports[`taskLog (isCI = false) > message > prints empty lines 1`] = `
 ",
   "[90m│[39m
 ",
-  "[90m│[39m  [2m[22m
-",
   "[90m│[39m  [2mline 1[22m
 ",
   "<erase.line><cursor.up count=1><erase.line><cursor.left count=1>",

--- a/packages/prompts/test/__snapshots__/task-log.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/task-log.test.ts.snap
@@ -46,6 +46,543 @@ exports[`taskLog (isCI = false) > error > renders output with message 1`] = `
 ]
 `;
 
+exports[`taskLog (isCI = false) > group > applies limit per group 1`] = `
+[
+  "[90m│[39m
+",
+  "[32m◇[39m  Some log
+",
+  "[90m│[39m
+",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m  [2mGroup 1 line 0[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+[90m│[39m  [2mGroup 0 line 1[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m  [2mGroup 1 line 0[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+[90m│[39m  [2mGroup 0 line 1[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m  [2mGroup 1 line 0[22m
+[90m│[39m  [2mGroup 1 line 1[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 1[22m
+[90m│[39m  [2mGroup 0 line 2[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m  [2mGroup 1 line 0[22m
+[90m│[39m  [2mGroup 1 line 1[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 1[22m
+[90m│[39m  [2mGroup 0 line 2[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m  [2mGroup 1 line 1[22m
+[90m│[39m  [2mGroup 1 line 2[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 2[22m
+[90m│[39m  [2mGroup 0 line 3[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m  [2mGroup 1 line 1[22m
+[90m│[39m  [2mGroup 1 line 2[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 2[22m
+[90m│[39m  [2mGroup 0 line 3[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m  [2mGroup 1 line 2[22m
+[90m│[39m  [2mGroup 1 line 3[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 3[22m
+[90m│[39m  [2mGroup 0 line 4[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m  [2mGroup 1 line 2[22m
+[90m│[39m  [2mGroup 1 line 3[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 3[22m
+[90m│[39m  [2mGroup 0 line 4[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m  [2mGroup 1 line 3[22m
+[90m│[39m  [2mGroup 1 line 4[22m
+",
+]
+`;
+
+exports[`taskLog (isCI = false) > group > can render multiple groups of different sizes 1`] = `
+[
+  "[90m│[39m
+",
+  "[32m◇[39m  Some log
+",
+  "[90m│[39m
+",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+[90m│[39m  [2mGroup 0 line 1[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+[90m│[39m  [2mGroup 0 line 1[22m
+[90m│[39m  [2mGroup 0 line 2[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+[90m│[39m  [2mGroup 0 line 1[22m
+[90m│[39m  [2mGroup 0 line 2[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m  [2mGroup 1 line 0[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+[90m│[39m  [2mGroup 0 line 1[22m
+[90m│[39m  [2mGroup 0 line 2[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m  [2mGroup 1 line 0[22m
+[90m│[39m  [2mGroup 1 line 1[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+[90m│[39m  [2mGroup 0 line 1[22m
+[90m│[39m  [2mGroup 0 line 2[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m  [2mGroup 1 line 0[22m
+[90m│[39m  [2mGroup 1 line 1[22m
+[90m│[39m  [2mGroup 1 line 2[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+[90m│[39m  [2mGroup 0 line 1[22m
+[90m│[39m  [2mGroup 0 line 2[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m  [2mGroup 1 line 0[22m
+[90m│[39m  [2mGroup 1 line 1[22m
+[90m│[39m  [2mGroup 1 line 2[22m
+[90m│[39m  [2mGroup 1 line 3[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+[90m│[39m  [2mGroup 0 line 1[22m
+[90m│[39m  [2mGroup 0 line 2[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m  [2mGroup 1 line 0[22m
+[90m│[39m  [2mGroup 1 line 1[22m
+[90m│[39m  [2mGroup 1 line 2[22m
+[90m│[39m  [2mGroup 1 line 3[22m
+[90m│[39m  [2mGroup 1 line 4[22m
+",
+]
+`;
+
+exports[`taskLog (isCI = false) > group > can render multiple groups of equal size 1`] = `
+[
+  "[90m│[39m
+",
+  "[32m◇[39m  Some log
+",
+  "[90m│[39m
+",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m  [2mGroup 1 line 0[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+[90m│[39m  [2mGroup 0 line 1[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m  [2mGroup 1 line 0[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+[90m│[39m  [2mGroup 0 line 1[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m  [2mGroup 1 line 0[22m
+[90m│[39m  [2mGroup 1 line 1[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+[90m│[39m  [2mGroup 0 line 1[22m
+[90m│[39m  [2mGroup 0 line 2[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m  [2mGroup 1 line 0[22m
+[90m│[39m  [2mGroup 1 line 1[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+[90m│[39m  [2mGroup 0 line 1[22m
+[90m│[39m  [2mGroup 0 line 2[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m  [2mGroup 1 line 0[22m
+[90m│[39m  [2mGroup 1 line 1[22m
+[90m│[39m  [2mGroup 1 line 2[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+[90m│[39m  [2mGroup 0 line 1[22m
+[90m│[39m  [2mGroup 0 line 2[22m
+[90m│[39m  [2mGroup 0 line 3[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m  [2mGroup 1 line 0[22m
+[90m│[39m  [2mGroup 1 line 1[22m
+[90m│[39m  [2mGroup 1 line 2[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+[90m│[39m  [2mGroup 0 line 1[22m
+[90m│[39m  [2mGroup 0 line 2[22m
+[90m│[39m  [2mGroup 0 line 3[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m  [2mGroup 1 line 0[22m
+[90m│[39m  [2mGroup 1 line 1[22m
+[90m│[39m  [2mGroup 1 line 2[22m
+[90m│[39m  [2mGroup 1 line 3[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+[90m│[39m  [2mGroup 0 line 1[22m
+[90m│[39m  [2mGroup 0 line 2[22m
+[90m│[39m  [2mGroup 0 line 3[22m
+[90m│[39m  [2mGroup 0 line 4[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m  [2mGroup 1 line 0[22m
+[90m│[39m  [2mGroup 1 line 1[22m
+[90m│[39m  [2mGroup 1 line 2[22m
+[90m│[39m  [2mGroup 1 line 3[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+[90m│[39m  [2mGroup 0 line 1[22m
+[90m│[39m  [2mGroup 0 line 2[22m
+[90m│[39m  [2mGroup 0 line 3[22m
+[90m│[39m  [2mGroup 0 line 4[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m  [2mGroup 1 line 0[22m
+[90m│[39m  [2mGroup 1 line 1[22m
+[90m│[39m  [2mGroup 1 line 2[22m
+[90m│[39m  [2mGroup 1 line 3[22m
+[90m│[39m  [2mGroup 1 line 4[22m
+",
+]
+`;
+
+exports[`taskLog (isCI = false) > group > renders error state 1`] = `
+[
+  "[90m│[39m
+",
+  "[32m◇[39m  Some log
+",
+  "[90m│[39m
+",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[31m■[39m  Group error!
+",
+]
+`;
+
+exports[`taskLog (isCI = false) > group > renders group error state 1`] = `
+[
+  "[90m│[39m
+",
+  "[32m◇[39m  Some log
+",
+  "[90m│[39m
+",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[31m■[39m  Group error!
+",
+]
+`;
+
+exports[`taskLog (isCI = false) > group > renders group success state 1`] = `
+[
+  "[90m│[39m
+",
+  "[32m◇[39m  Some log
+",
+  "[90m│[39m
+",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[32m◆[39m  Group success!
+",
+]
+`;
+
+exports[`taskLog (isCI = false) > group > renders success state 1`] = `
+[
+  "[90m│[39m
+",
+  "[32m◇[39m  Some log
+",
+  "[90m│[39m
+",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[32m◆[39m  Group success!
+",
+]
+`;
+
+exports[`taskLog (isCI = false) > group > showLog shows all groups in order 1`] = `
+[
+  "[90m│[39m
+",
+  "[32m◇[39m  Some log
+",
+  "[90m│[39m
+",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+[90m│[39m  [2mGroup 0 line 1[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+[90m│[39m  [2mGroup 0 line 1[22m
+[90m│[39m  [2mGroup 0 line 2[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+[90m│[39m  [2mGroup 0 line 1[22m
+[90m│[39m  [2mGroup 0 line 2[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m  [2mGroup 1 line 0[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+[90m│[39m  [2mGroup 0 line 1[22m
+[90m│[39m  [2mGroup 0 line 2[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m  [2mGroup 1 line 0[22m
+[90m│[39m  [2mGroup 1 line 1[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+[90m│[39m  [2mGroup 0 line 1[22m
+[90m│[39m  [2mGroup 0 line 2[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m  [2mGroup 1 line 0[22m
+[90m│[39m  [2mGroup 1 line 1[22m
+[90m│[39m  [2mGroup 1 line 2[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+[90m│[39m  [2mGroup 0 line 1[22m
+[90m│[39m  [2mGroup 0 line 2[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m  [2mGroup 1 line 0[22m
+[90m│[39m  [2mGroup 1 line 1[22m
+[90m│[39m  [2mGroup 1 line 2[22m
+[90m│[39m  [2mGroup 1 line 3[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m  [2mGroup 0 line 0[22m
+[90m│[39m  [2mGroup 0 line 1[22m
+[90m│[39m  [2mGroup 0 line 2[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m  [2mGroup 1 line 0[22m
+[90m│[39m  [2mGroup 1 line 1[22m
+[90m│[39m  [2mGroup 1 line 2[22m
+[90m│[39m  [2mGroup 1 line 3[22m
+[90m│[39m  [2mGroup 1 line 4[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[32m◆[39m  Group 0 success!
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m  [2mGroup 1 line 0[22m
+[90m│[39m  [2mGroup 1 line 1[22m
+[90m│[39m  [2mGroup 1 line 2[22m
+[90m│[39m  [2mGroup 1 line 3[22m
+[90m│[39m  [2mGroup 1 line 4[22m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[32m◆[39m  Group 0 success!
+",
+  "[31m■[39m  Group 1 error!
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m
+[31m■[39m  overall error
+",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m
+[90m│[39m  [2mGroup 0 line 0[22m
+[90m│[39m  [2mGroup 0 line 1[22m
+[90m│[39m  [2mGroup 0 line 2[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m
+[90m│[39m  [2mGroup 1 line 0[22m
+[90m│[39m  [2mGroup 1 line 1[22m
+[90m│[39m  [2mGroup 1 line 2[22m
+[90m│[39m  [2mGroup 1 line 3[22m
+[90m│[39m  [2mGroup 1 line 4[22m
+",
+]
+`;
+
 exports[`taskLog (isCI = false) > message > can write line by line 1`] = `
 [
   "[90m│[39m
@@ -624,6 +1161,152 @@ exports[`taskLog (isCI = true) > error > renders output with message 1`] = `
   "[90m│[39m
 [90m│[39m  [2mline 0[22m
 [90m│[39m  [2mline 1[22m
+",
+]
+`;
+
+exports[`taskLog (isCI = true) > group > applies limit per group 1`] = `
+[
+  "[90m│[39m
+",
+  "[32m◇[39m  Some log
+",
+  "[90m│[39m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+]
+`;
+
+exports[`taskLog (isCI = true) > group > can render multiple groups of different sizes 1`] = `
+[
+  "[90m│[39m
+",
+  "[32m◇[39m  Some log
+",
+  "[90m│[39m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+]
+`;
+
+exports[`taskLog (isCI = true) > group > can render multiple groups of equal size 1`] = `
+[
+  "[90m│[39m
+",
+  "[32m◇[39m  Some log
+",
+  "[90m│[39m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+]
+`;
+
+exports[`taskLog (isCI = true) > group > renders error state 1`] = `
+[
+  "[90m│[39m
+",
+  "[32m◇[39m  Some log
+",
+  "[90m│[39m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+]
+`;
+
+exports[`taskLog (isCI = true) > group > renders group error state 1`] = `
+[
+  "[90m│[39m
+",
+  "[32m◇[39m  Some log
+",
+  "[90m│[39m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+]
+`;
+
+exports[`taskLog (isCI = true) > group > renders group success state 1`] = `
+[
+  "[90m│[39m
+",
+  "[32m◇[39m  Some log
+",
+  "[90m│[39m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+]
+`;
+
+exports[`taskLog (isCI = true) > group > renders success state 1`] = `
+[
+  "[90m│[39m
+",
+  "[32m◇[39m  Some log
+",
+  "[90m│[39m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+]
+`;
+
+exports[`taskLog (isCI = true) > group > showLog shows all groups in order 1`] = `
+[
+  "[90m│[39m
+",
+  "[32m◇[39m  Some log
+",
+  "[90m│[39m
+",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "<erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.up count=1><erase.line><cursor.left count=1>",
+  "[90m│[39m
+[31m■[39m  overall error
+",
+  "[90m│[39m  [1mGroup 0[22m
+",
+  "[90m│[39m
+[90m│[39m  [2mGroup 0 line 0[22m
+[90m│[39m  [2mGroup 0 line 1[22m
+[90m│[39m  [2mGroup 0 line 2[22m
+",
+  "[90m│[39m  [1mGroup 1[22m
+",
+  "[90m│[39m
+[90m│[39m  [2mGroup 1 line 0[22m
+[90m│[39m  [2mGroup 1 line 1[22m
+[90m│[39m  [2mGroup 1 line 2[22m
+[90m│[39m  [2mGroup 1 line 3[22m
+[90m│[39m  [2mGroup 1 line 4[22m
 ",
 ]
 `;

--- a/packages/prompts/test/task-log.test.ts
+++ b/packages/prompts/test/task-log.test.ts
@@ -126,7 +126,6 @@ describe.each(['true', 'false'])('taskLog (isCI = %s)', (isCI) => {
 				title: 'foo',
 			});
 
-			log.message('');
 			log.message('line 1');
 			log.message('');
 			log.message('line 3');

--- a/packages/prompts/test/task-log.test.ts
+++ b/packages/prompts/test/task-log.test.ts
@@ -419,5 +419,18 @@ describe.each(['true', 'false'])('taskLog (isCI = %s)', (isCI) => {
 
 			expect(output.buffer).toMatchSnapshot();
 		});
+
+		test('handles empty groups', async () => {
+			const log = prompts.taskLog({
+				title: 'Some log',
+				input,
+				output
+			});
+			const group = log.group('Group 0');
+
+			group.success('Group success!');
+
+			expect(output.buffer).toMatchSnapshot();
+		});
 	});
 });

--- a/packages/prompts/test/task-log.test.ts
+++ b/packages/prompts/test/task-log.test.ts
@@ -18,6 +18,7 @@ describe.each(['true', 'false'])('taskLog (isCI = %s)', (isCI) => {
 
 	beforeEach(() => {
 		output = new MockWritable();
+		output.isTTY = isCI === 'false';
 		input = new MockReadable();
 	});
 

--- a/packages/prompts/test/task-log.test.ts
+++ b/packages/prompts/test/task-log.test.ts
@@ -288,4 +288,136 @@ describe.each(['true', 'false'])('taskLog (isCI = %s)', (isCI) => {
 			});
 		});
 	});
+
+	describe('group', () => {
+		test('can render multiple groups of equal size', async () => {
+			const log = prompts.taskLog({
+				title: 'Some log',
+				input,
+				output
+			});
+			const group0 = log.group('Group 0');
+			const group1 = log.group('Group 1');
+
+			for (let i = 0; i < 5; i++) {
+				group0.message(`Group 0 line ${i}`);
+				group1.message(`Group 1 line ${i}`);
+			}
+
+			expect(output.buffer).toMatchSnapshot();
+		});
+
+		test('can render multiple groups of different sizes', async () => {
+			const log = prompts.taskLog({
+				title: 'Some log',
+				input,
+				output
+			});
+			const group0 = log.group('Group 0');
+			const group1 = log.group('Group 1');
+
+			for (let i = 0; i < 3; i++) {
+				group0.message(`Group 0 line ${i}`);
+			}
+			for (let i = 0; i < 5; i++) {
+				group1.message(`Group 1 line ${i}`);
+			}
+
+			expect(output.buffer).toMatchSnapshot();
+		});
+
+		test('renders success state', async () => {
+			const log = prompts.taskLog({
+				title: 'Some log',
+				input,
+				output
+			});
+			const group = log.group('Group 0');
+			group.message(`Group 0 line 0`);
+			group.success('Group success!');
+
+			expect(output.buffer).toMatchSnapshot();
+		});
+
+		test('renders error state', async () => {
+			const log = prompts.taskLog({
+				title: 'Some log',
+				input,
+				output
+			});
+			const group = log.group('Group 0');
+			group.message(`Group 0 line 0`);
+			group.error('Group error!');
+
+			expect(output.buffer).toMatchSnapshot();
+		});
+
+		test('applies limit per group', async () => {
+			const log = prompts.taskLog({
+				title: 'Some log',
+				input,
+				output,
+				limit: 2,
+			});
+			const group0 = log.group('Group 0');
+			const group1 = log.group('Group 1');
+
+			for (let i = 0; i < 5; i++) {
+				group0.message(`Group 0 line ${i}`);
+				group1.message(`Group 1 line ${i}`);
+			}
+
+			expect(output.buffer).toMatchSnapshot();
+		});
+
+		test('renders group success state', async () => {
+			const log = prompts.taskLog({
+				title: 'Some log',
+				input,
+				output
+			});
+			const group = log.group('Group 0');
+			group.message(`Group 0 line 0`);
+			group.success('Group success!');
+
+			expect(output.buffer).toMatchSnapshot();
+		});
+
+		test('renders group error state', async () => {
+			const log = prompts.taskLog({
+				title: 'Some log',
+				input,
+				output
+			});
+			const group = log.group('Group 0');
+			group.message(`Group 0 line 0`);
+			group.error('Group error!');
+
+			expect(output.buffer).toMatchSnapshot();
+		});
+
+		test('showLog shows all groups in order', async () => {
+			const log = prompts.taskLog({
+				title: 'Some log',
+				input,
+				output,
+			});
+			const group0 = log.group('Group 0');
+			const group1 = log.group('Group 1');
+
+			for (let i = 0; i < 3; i++) {
+				group0.message(`Group 0 line ${i}`);
+			}
+			for (let i = 0; i < 5; i++) {
+				group1.message(`Group 1 line ${i}`);
+			}
+
+			group0.success('Group 0 success!');
+			group1.error('Group 1 error!');
+
+			log.error('overall error', {showLog: true});
+
+			expect(output.buffer).toMatchSnapshot();
+		});
+	});
 });

--- a/packages/prompts/test/test-utils.ts
+++ b/packages/prompts/test/test-utils.ts
@@ -2,6 +2,7 @@ import { Readable, Writable } from 'node:stream';
 
 export class MockWritable extends Writable {
 	public buffer: string[] = [];
+	public isTTY = false;
 
 	_write(
 		chunk: any,


### PR DESCRIPTION
This allows you to have tasklog groups.

Basically this:

```ts
const log = p.taskLog({
	title: 'yes?',
	limit: 5,
});

const group0 = log.group('group 0');
const group1 = log.group('group 1');

await Promise.all([
	(async () => {
		for (let i = 0; i < 10; i++) {
			group0.message(`foo ${i} bar`);
			await new Promise((r) => {
				setTimeout(r, 1000);
			});
		}
		group0.success('group 0 done!');
	})(),
	(async () => {
		for (let i = 0; i < 10; i++) {
			group1.message(`foo ${i} bar`);
			await new Promise((r) => {
				setTimeout(r, 500);
			});
		}
		group1.success('group 1 done!');
	})(),
]);

await new Promise((r) => {
	setTimeout(r, 1000);
});
log.success('yes!');
```

this will result in a scrolling task log whose sub-logs have a `limit: 5` (i.e. the overall log has no such limit)

once inner logs complete, they collapse as normal

once the overall log completes, we collapse the entire thing and output the log if specified

cc @yannbf