### PR TITLE
fix: correctly display deleted message

### DIFF
--- a/packages/core/src/prompts/prompt.ts
+++ b/packages/core/src/prompts/prompt.ts
@@ -261,7 +261,7 @@ export default class Prompt<TValue> {
 	}
 
 	private render() {
-		const frame = wrap(this._render(this) ?? '', process.stdout.columns, { hard: true });
+		const frame = wrap(this._render(this) ?? '', process.stdout.columns, { hard: true, trim: this.state === 'cancel' ? false : undefined });
 		if (frame === this._prevFrame) return;
 
 		if (this.state === 'initial') {


### PR DESCRIPTION
When the text method is called, and a message with spaces before and after it is entered in the terminal, ` a `, and then the operation is canceled, you can see that the entered message is deleted, but the space after the message is also removed. The displayed message is inconsistent with the input.

|before|after|
|---|---|
|![image](https://github.com/user-attachments/assets/467398c3-b6cf-41e5-a45d-24d0d7e90fcc)|![image](https://github.com/user-attachments/assets/c9c1202c-3a83-4626-927a-edcaa3b61a02)|
