### PR TITLE
feat(autocomplete-multiselect): allow select all and selecting inverse using shift up/down

### DIFF
--- a/.changeset/happy-spoons-push.md
+++ b/.changeset/happy-spoons-push.md
@@ -1,0 +1,6 @@
+---
+"@clack/prompts": minor
+"@clack/core": minor
+---
+
+add inversion and selecting all options for autocomplete multiselect

--- a/packages/core/src/prompts/autocomplete.ts
+++ b/packages/core/src/prompts/autocomplete.ts
@@ -140,6 +140,8 @@ export default class AutocompletePrompt<T extends OptionLike> extends Prompt<
 		const isUpKey = key.name === 'up';
 		const isDownKey = key.name === 'down';
 		const isReturnKey = key.name === 'return';
+		const isLeft = key.name === 'left';
+		const isRight = key.name === 'right';
 
 		// Start navigation mode with up/down arrows
 		if (isUpKey || isDownKey) {
@@ -161,6 +163,15 @@ export default class AutocompletePrompt<T extends OptionLike> extends Prompt<
 					(key.name === 'tab' || (this.isNavigating && key.name === 'space'))
 				) {
 					this.toggleSelected(this.focusedValue);
+				} else if (isLeft) {
+					// set to none if all are selected
+					if (this.selectedValues.length === this.filteredOptions.length) {
+						this.deselectAll();
+					} else {
+						this.selectAll();
+					}
+				} else if (isRight) {
+					this.invertSelected();
 				} else {
 					this.isNavigating = false;
 				}
@@ -173,8 +184,18 @@ export default class AutocompletePrompt<T extends OptionLike> extends Prompt<
 		}
 	}
 
+	selectAll() {
+		this.selectedValues = this.filteredOptions.map((opt) => opt.value);
+	}
+
 	deselectAll() {
 		this.selectedValues = [];
+	}
+
+	invertSelected() {
+		this.selectedValues = this.filteredOptions
+			.filter((opt) => !this.selectedValues.includes(opt.value))
+			.map((opt) => opt.value);
 	}
 
 	toggleSelected(value: T['value']) {

--- a/packages/core/src/prompts/autocomplete.ts
+++ b/packages/core/src/prompts/autocomplete.ts
@@ -140,11 +140,15 @@ export default class AutocompletePrompt<T extends OptionLike> extends Prompt<
 		const isUpKey = key.name === 'up';
 		const isDownKey = key.name === 'down';
 		const isReturnKey = key.name === 'return';
-		const isLeft = key.name === 'left';
-		const isRight = key.name === 'right';
 
 		// Start navigation mode with up/down arrows
 		if (isUpKey || isDownKey) {
+			// shift up/down behavior
+			if (key.shift) {
+				this.#handleShiftNavigation(isUpKey);
+				return;
+			}
+
 			this.#cursor = Math.max(
 				0,
 				Math.min(this.#cursor + (isUpKey ? -1 : 1), this.filteredOptions.length - 1)
@@ -163,15 +167,6 @@ export default class AutocompletePrompt<T extends OptionLike> extends Prompt<
 					(key.name === 'tab' || (this.isNavigating && key.name === 'space'))
 				) {
 					this.toggleSelected(this.focusedValue);
-				} else if (isLeft) {
-					// set to none if all are selected
-					if (this.selectedValues.length === this.filteredOptions.length) {
-						this.deselectAll();
-					} else {
-						this.selectAll();
-					}
-				} else if (isRight) {
-					this.invertSelected();
 				} else {
 					this.isNavigating = false;
 				}
@@ -184,18 +179,41 @@ export default class AutocompletePrompt<T extends OptionLike> extends Prompt<
 		}
 	}
 
-	selectAll() {
+	#handleShiftNavigation(isUpKey: boolean) {
+		// invert if Shift + Down
+		if (!isUpKey) {
+			this.invertSelectedFiltered();
+			return;
+		}
+
+		// set to none if all are selected
+		if (this.selectedValues.length === this.filteredOptions.length) {
+			this.deselectAllFiltered();
+			return;
+		}
+
+		this.selectAllFiltered();
+		return;
+	}
+
+	selectAllFiltered() {
 		this.selectedValues = this.filteredOptions.map((opt) => opt.value);
+	}
+
+	deselectAllFiltered() {
+		this.selectedValues = this.filteredOptions
+			.filter((opt) => !this.selectedValues.includes(opt.value))
+			.map((opt) => opt.value);
+	}
+
+	invertSelectedFiltered() {
+		this.selectedValues = this.filteredOptions
+			.filter((opt) => !this.selectedValues.includes(opt.value))
+			.map((opt) => opt.value);
 	}
 
 	deselectAll() {
 		this.selectedValues = [];
-	}
-
-	invertSelected() {
-		this.selectedValues = this.filteredOptions
-			.filter((opt) => !this.selectedValues.includes(opt.value))
-			.map((opt) => opt.value);
 	}
 
 	toggleSelected(value: T['value']) {

--- a/packages/prompts/src/autocomplete.ts
+++ b/packages/prompts/src/autocomplete.ts
@@ -96,7 +96,6 @@ export const autocomplete = <Value>(opts: AutocompleteOptions<Value>) => {
 			const placeholder = opts.placeholder;
 			const showPlaceholder = valueAsString === '' && placeholder !== undefined;
 
-			console.log(this.state);
 			// Handle different states
 			switch (this.state) {
 				case 'submit': {
@@ -276,7 +275,7 @@ export const autocompleteMultiselect = <Value>(opts: AutocompleteMultiSelectOpti
 					// Instructions
 					const instructions = [
 						`${color.dim('↑/↓')} to navigate`,
-						`${color.dim('←/→')} select all/inverse`,
+						`${color.dim('Ctrl+↑/↓')} select all/inverse`,
 						`${color.dim('Space:')} select`,
 						`${color.dim('Enter:')} confirm`,
 						`${color.dim('Type:')} to search`,

--- a/packages/prompts/src/autocomplete.ts
+++ b/packages/prompts/src/autocomplete.ts
@@ -96,6 +96,7 @@ export const autocomplete = <Value>(opts: AutocompleteOptions<Value>) => {
 			const placeholder = opts.placeholder;
 			const showPlaceholder = valueAsString === '' && placeholder !== undefined;
 
+			console.log(this.state);
 			// Handle different states
 			switch (this.state) {
 				case 'submit': {
@@ -275,6 +276,7 @@ export const autocompleteMultiselect = <Value>(opts: AutocompleteMultiSelectOpti
 					// Instructions
 					const instructions = [
 						`${color.dim('↑/↓')} to navigate`,
+						`${color.dim('←/→')} select all/inverse`,
 						`${color.dim('Space:')} select`,
 						`${color.dim('Enter:')} confirm`,
 						`${color.dim('Type:')} to search`,

--- a/packages/prompts/test/__snapshots__/autocomplete.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/autocomplete.test.ts.snap
@@ -298,7 +298,7 @@ exports[`autocompleteMultiselect > all selection only applies to filtered option
 [36m│[39m  [2m◻[22m [2mCherry[22m
 [36m│[39m  [2m◻[22m [2mGrape[22m
 [36m│[39m  [2m◻[22m [2mOrange[22m
-[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mCtrl+↑/↓[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=3>",
@@ -307,16 +307,15 @@ exports[`autocompleteMultiselect > all selection only applies to filtered option
 [36m│[39m  [2m◻[22m Cherry
 [36m│[39m  [2m◻[22m [2mGrape[22m
 [36m│[39m  [2m◻[22m [2mOrange[22m
-[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mCtrl+↑/↓[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=8>",
-  "<cursor.down count=3>",
+  "<cursor.down count=4>",
   "<erase.down>",
-  "[36m│[39m  [2mSearch:[22m [7mr[27m[2m (3 matches)[22m
-[36m│[39m  [32m◼[39m Cherry
+  "[36m│[39m  [32m◼[39m Cherry
 [36m│[39m  [32m◼[39m [2mGrape[22m
 [36m│[39m  [32m◼[39m [2mOrange[22m
-[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mCtrl+↑/↓[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=8>",
   "<cursor.down count=1>",
@@ -341,7 +340,7 @@ exports[`autocompleteMultiselect > can be aborted by a signal 1`] = `
 [36m│[39m  [2m◻[22m [2mCherry[22m
 [36m│[39m  [2m◻[22m [2mGrape[22m
 [36m│[39m  [2m◻[22m [2mOrange[22m
-[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mCtrl+↑/↓[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
   "
 ",
@@ -361,7 +360,7 @@ exports[`autocompleteMultiselect > everything can be selected with left arrow 1`
 [36m│[39m  [2m◻[22m [2mCherry[22m
 [36m│[39m  [2m◻[22m [2mGrape[22m
 [36m│[39m  [2m◻[22m [2mOrange[22m
-[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mCtrl+↑/↓[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=4>",
@@ -371,7 +370,7 @@ exports[`autocompleteMultiselect > everything can be selected with left arrow 1`
 [36m│[39m  [32m◼[39m [2mCherry[22m
 [36m│[39m  [32m◼[39m [2mGrape[22m
 [36m│[39m  [32m◼[39m [2mOrange[22m
-[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mCtrl+↑/↓[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=1>",
@@ -396,7 +395,7 @@ exports[`autocompleteMultiselect > everything is deselected if left is pressed a
 [36m│[39m  [2m◻[22m [2mCherry[22m
 [36m│[39m  [2m◻[22m [2mGrape[22m
 [36m│[39m  [2m◻[22m [2mOrange[22m
-[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mCtrl+↑/↓[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=4>",
@@ -406,7 +405,7 @@ exports[`autocompleteMultiselect > everything is deselected if left is pressed a
 [36m│[39m  [32m◼[39m [2mCherry[22m
 [36m│[39m  [32m◼[39m [2mGrape[22m
 [36m│[39m  [32m◼[39m [2mOrange[22m
-[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mCtrl+↑/↓[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=4>",
@@ -416,7 +415,7 @@ exports[`autocompleteMultiselect > everything is deselected if left is pressed a
 [36m│[39m  [2m◻[22m [2mCherry[22m
 [36m│[39m  [2m◻[22m [2mGrape[22m
 [36m│[39m  [2m◻[22m [2mOrange[22m
-[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mCtrl+↑/↓[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=1>",
@@ -441,7 +440,7 @@ exports[`autocompleteMultiselect > inverse can be selected with right arrow 1`] 
 [36m│[39m  [2m◻[22m [2mCherry[22m
 [36m│[39m  [2m◻[22m [2mGrape[22m
 [36m│[39m  [2m◻[22m [2mOrange[22m
-[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mCtrl+↑/↓[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=3>",
@@ -452,7 +451,7 @@ exports[`autocompleteMultiselect > inverse can be selected with right arrow 1`] 
 [36m│[39m  [2m◻[22m [2mCherry[22m
 [36m│[39m  [2m◻[22m [2mGrape[22m
 [36m│[39m  [2m◻[22m [2mOrange[22m
-[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mCtrl+↑/↓[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=5>",
@@ -467,7 +466,7 @@ exports[`autocompleteMultiselect > inverse can be selected with right arrow 1`] 
 [36m│[39m  [32m◼[39m [2mCherry[22m
 [36m│[39m  [32m◼[39m [2mGrape[22m
 [36m│[39m  [32m◼[39m [2mOrange[22m
-[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mCtrl+↑/↓[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=1>",
@@ -492,7 +491,7 @@ exports[`autocompleteMultiselect > inversion only applies to filtered options 1`
 [36m│[39m  [2m◻[22m [2mCherry[22m
 [36m│[39m  [2m◻[22m [2mGrape[22m
 [36m│[39m  [2m◻[22m [2mOrange[22m
-[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mCtrl+↑/↓[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=3>",
@@ -501,7 +500,7 @@ exports[`autocompleteMultiselect > inversion only applies to filtered options 1`
 [36m│[39m  [2m◻[22m Cherry
 [36m│[39m  [2m◻[22m [2mGrape[22m
 [36m│[39m  [2m◻[22m [2mOrange[22m
-[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mCtrl+↑/↓[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=8>",
   "<cursor.down count=3>",
@@ -510,7 +509,7 @@ exports[`autocompleteMultiselect > inversion only applies to filtered options 1`
 [36m│[39m  [2m◻[22m [2mCherry[22m
 [36m│[39m  [2m◻[22m Grape
 [36m│[39m  [2m◻[22m [2mOrange[22m
-[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mCtrl+↑/↓[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=8>",
   "<cursor.down count=5>",
@@ -523,7 +522,7 @@ exports[`autocompleteMultiselect > inversion only applies to filtered options 1`
   "[36m│[39m  [32m◼[39m [2mCherry[22m
 [36m│[39m  [2m◻[22m Grape
 [36m│[39m  [32m◼[39m [2mOrange[22m
-[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mCtrl+↑/↓[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=8>",
   "<cursor.down count=1>",
@@ -548,7 +547,7 @@ exports[`autocompleteMultiselect > renders error when empty selection & required
 [36m│[39m  [2m◻[22m [2mCherry[22m
 [36m│[39m  [2m◻[22m [2mGrape[22m
 [36m│[39m  [2m◻[22m [2mOrange[22m
-[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mCtrl+↑/↓[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=1>",
@@ -562,7 +561,7 @@ exports[`autocompleteMultiselect > renders error when empty selection & required
 [36m│[39m  [2m◻[22m [2mCherry[22m
 [36m│[39m  [2m◻[22m [2mGrape[22m
 [36m│[39m  [2m◻[22m [2mOrange[22m
-[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mCtrl+↑/↓[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=11>",
   "<cursor.down count=1>",
@@ -575,7 +574,7 @@ exports[`autocompleteMultiselect > renders error when empty selection & required
 [36m│[39m  [2m◻[22m [2mCherry[22m
 [36m│[39m  [2m◻[22m [2mGrape[22m
 [36m│[39m  [2m◻[22m [2mOrange[22m
-[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mCtrl+↑/↓[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=1>",

--- a/packages/prompts/test/__snapshots__/autocomplete.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/autocomplete.test.ts.snap
@@ -286,6 +286,49 @@ exports[`autocomplete > supports initialValue 1`] = `
 ]
 `;
 
+exports[`autocompleteMultiselect > all selection only applies to filtered options 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  Select a fruit
+
+[36m│[39m  [2mSearch:[22m [7m[8m_[28m[27m
+[36m│[39m  [2m◻[22m Apple
+[36m│[39m  [2m◻[22m [2mBanana[22m
+[36m│[39m  [2m◻[22m [2mCherry[22m
+[36m│[39m  [2m◻[22m [2mGrape[22m
+[36m│[39m  [2m◻[22m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=10>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2mSearch:[22m r█[2m (3 matches)[22m
+[36m│[39m  [2m◻[22m Cherry
+[36m│[39m  [2m◻[22m [2mGrape[22m
+[36m│[39m  [2m◻[22m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=8>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2mSearch:[22m [7mr[27m[2m (3 matches)[22m
+[36m│[39m  [32m◼[39m Cherry
+[36m│[39m  [32m◼[39m [2mGrape[22m
+[36m│[39m  [32m◼[39m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=8>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  Select a fruit
+[90m│[39m  [2m3 items selected[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
 exports[`autocompleteMultiselect > can be aborted by a signal 1`] = `
 [
   "<cursor.hide>",
@@ -298,8 +341,195 @@ exports[`autocompleteMultiselect > can be aborted by a signal 1`] = `
 [36m│[39m  [2m◻[22m [2mCherry[22m
 [36m│[39m  [2m◻[22m [2mGrape[22m
 [36m│[39m  [2m◻[22m [2mOrange[22m
-[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`autocompleteMultiselect > everything can be selected with left arrow 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  Select a fruit
+
+[36m│[39m  [2mSearch:[22m [7m[8m_[28m[27m
+[36m│[39m  [2m◻[22m Apple
+[36m│[39m  [2m◻[22m [2mBanana[22m
+[36m│[39m  [2m◻[22m [2mCherry[22m
+[36m│[39m  [2m◻[22m [2mGrape[22m
+[36m│[39m  [2m◻[22m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=10>",
+  "<cursor.down count=4>",
+  "<erase.down>",
+  "[36m│[39m  [32m◼[39m Apple
+[36m│[39m  [32m◼[39m [2mBanana[22m
+[36m│[39m  [32m◼[39m [2mCherry[22m
+[36m│[39m  [32m◼[39m [2mGrape[22m
+[36m│[39m  [32m◼[39m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=10>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  Select a fruit
+[90m│[39m  [2m5 items selected[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`autocompleteMultiselect > everything is deselected if left is pressed again 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  Select a fruit
+
+[36m│[39m  [2mSearch:[22m [7m[8m_[28m[27m
+[36m│[39m  [2m◻[22m Apple
+[36m│[39m  [2m◻[22m [2mBanana[22m
+[36m│[39m  [2m◻[22m [2mCherry[22m
+[36m│[39m  [2m◻[22m [2mGrape[22m
+[36m│[39m  [2m◻[22m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=10>",
+  "<cursor.down count=4>",
+  "<erase.down>",
+  "[36m│[39m  [32m◼[39m Apple
+[36m│[39m  [32m◼[39m [2mBanana[22m
+[36m│[39m  [32m◼[39m [2mCherry[22m
+[36m│[39m  [32m◼[39m [2mGrape[22m
+[36m│[39m  [32m◼[39m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=10>",
+  "<cursor.down count=4>",
+  "<erase.down>",
+  "[36m│[39m  [2m◻[22m Apple
+[36m│[39m  [2m◻[22m [2mBanana[22m
+[36m│[39m  [2m◻[22m [2mCherry[22m
+[36m│[39m  [2m◻[22m [2mGrape[22m
+[36m│[39m  [2m◻[22m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=10>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  Select a fruit
+[90m│[39m  [2m0 items selected[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`autocompleteMultiselect > inverse can be selected with right arrow 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  Select a fruit
+
+[36m│[39m  [2mSearch:[22m [7m[8m_[28m[27m
+[36m│[39m  [2m◻[22m Apple
+[36m│[39m  [2m◻[22m [2mBanana[22m
+[36m│[39m  [2m◻[22m [2mCherry[22m
+[36m│[39m  [2m◻[22m [2mGrape[22m
+[36m│[39m  [2m◻[22m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=10>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2mSearch:[22m [2m[22m
+[36m│[39m  [2m◻[22m [2mApple[22m
+[36m│[39m  [2m◻[22m Banana
+[36m│[39m  [2m◻[22m [2mCherry[22m
+[36m│[39m  [2m◻[22m [2mGrape[22m
+[36m│[39m  [2m◻[22m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=10>",
+  "<cursor.down count=5>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  [32m◼[39m Banana",
+  "<cursor.down count=5>",
+  "<cursor.backward count=999><cursor.up count=10>",
+  "<cursor.down count=4>",
+  "<erase.down>",
+  "[36m│[39m  [32m◼[39m [2mApple[22m
+[36m│[39m  [2m◻[22m Banana
+[36m│[39m  [32m◼[39m [2mCherry[22m
+[36m│[39m  [32m◼[39m [2mGrape[22m
+[36m│[39m  [32m◼[39m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=10>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  Select a fruit
+[90m│[39m  [2m4 items selected[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`autocompleteMultiselect > inversion only applies to filtered options 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  Select a fruit
+
+[36m│[39m  [2mSearch:[22m [7m[8m_[28m[27m
+[36m│[39m  [2m◻[22m Apple
+[36m│[39m  [2m◻[22m [2mBanana[22m
+[36m│[39m  [2m◻[22m [2mCherry[22m
+[36m│[39m  [2m◻[22m [2mGrape[22m
+[36m│[39m  [2m◻[22m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=10>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2mSearch:[22m r█[2m (3 matches)[22m
+[36m│[39m  [2m◻[22m Cherry
+[36m│[39m  [2m◻[22m [2mGrape[22m
+[36m│[39m  [2m◻[22m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=8>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2mSearch:[22m [2mr[22m[2m (3 matches)[22m
+[36m│[39m  [2m◻[22m [2mCherry[22m
+[36m│[39m  [2m◻[22m Grape
+[36m│[39m  [2m◻[22m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=8>",
+  "<cursor.down count=5>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  [32m◼[39m Grape",
+  "<cursor.down count=3>",
+  "<cursor.backward count=999><cursor.up count=8>",
+  "<cursor.down count=4>",
+  "<erase.down>",
+  "[36m│[39m  [32m◼[39m [2mCherry[22m
+[36m│[39m  [2m◻[22m Grape
+[36m│[39m  [32m◼[39m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=8>",
+  "<cursor.down count=1>",
+  "<erase.down>",
+  "[32m◇[39m  Select a fruit
+[90m│[39m  [2m2 items selected[22m",
   "
 ",
   "<cursor.show>",
@@ -318,7 +548,7 @@ exports[`autocompleteMultiselect > renders error when empty selection & required
 [36m│[39m  [2m◻[22m [2mCherry[22m
 [36m│[39m  [2m◻[22m [2mGrape[22m
 [36m│[39m  [2m◻[22m [2mOrange[22m
-[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=1>",
@@ -332,7 +562,7 @@ exports[`autocompleteMultiselect > renders error when empty selection & required
 [36m│[39m  [2m◻[22m [2mCherry[22m
 [36m│[39m  [2m◻[22m [2mGrape[22m
 [36m│[39m  [2m◻[22m [2mOrange[22m
-[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=11>",
   "<cursor.down count=1>",
@@ -345,7 +575,7 @@ exports[`autocompleteMultiselect > renders error when empty selection & required
 [36m│[39m  [2m◻[22m [2mCherry[22m
 [36m│[39m  [2m◻[22m [2mGrape[22m
 [36m│[39m  [2m◻[22m [2mOrange[22m
-[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2m←/→[22m[2m select all/inverse • [2mSpace:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
 [36m└[39m",
   "<cursor.backward count=999><cursor.up count=10>",
   "<cursor.down count=1>",

--- a/packages/prompts/test/autocomplete.test.ts
+++ b/packages/prompts/test/autocomplete.test.ts
@@ -230,7 +230,7 @@ describe('autocompleteMultiselect', () => {
 			output,
 		});
 
-		input.emit('keypress', '', { name: 'left' });
+		input.emit('keypress', '', { name: 'up', shift: true });
 		input.emit('keypress', '', { name: 'return' });
 		await result;
 		expect(output.buffer).toMatchSnapshot();
@@ -245,8 +245,8 @@ describe('autocompleteMultiselect', () => {
 			output,
 		});
 
-		input.emit('keypress', '', { name: 'left' });
-		input.emit('keypress', '', { name: 'left' });
+		input.emit('keypress', '', { name: 'up', shift: true });
+		input.emit('keypress', '', { name: 'up', shift: true });
 		input.emit('keypress', '', { name: 'return' });
 		await result;
 		expect(output.buffer).toMatchSnapshot();
@@ -263,7 +263,7 @@ describe('autocompleteMultiselect', () => {
 
 		input.emit('keypress', '', { name: 'down' });
 		input.emit('keypress', '', { name: 'space' });
-		input.emit('keypress', '', { name: 'right' });
+		input.emit('keypress', '', { name: 'down', shift: true });
 		input.emit('keypress', '', { name: 'return' });
 		await result;
 		expect(output.buffer).toMatchSnapshot();
@@ -279,7 +279,7 @@ describe('autocompleteMultiselect', () => {
 		});
 
 		input.emit('keypress', 'r', { name: 'r' });
-		input.emit('keypress', '', { name: 'left' });
+		input.emit('keypress', '', { name: 'up', shift: true });
 		input.emit('keypress', '', { name: 'return' });
 		await result;
 		expect(output.buffer).toMatchSnapshot();
@@ -297,7 +297,7 @@ describe('autocompleteMultiselect', () => {
 		input.emit('keypress', 'r', { name: 'r' });
 		input.emit('keypress', '', { name: 'down' });
 		input.emit('keypress', '', { name: 'space' });
-		input.emit('keypress', '', { name: 'right' });
+		input.emit('keypress', '', { name: 'down', shift: true });
 		input.emit('keypress', '', { name: 'return' });
 		await result;
 		expect(output.buffer).toMatchSnapshot();

--- a/packages/prompts/test/autocomplete.test.ts
+++ b/packages/prompts/test/autocomplete.test.ts
@@ -221,4 +221,86 @@ describe('autocompleteMultiselect', () => {
 		expect(isCancel(value)).toBe(true);
 		expect(output.buffer).toMatchSnapshot();
 	});
+
+	test('everything can be selected with left arrow', async () => {
+		const result = autocompleteMultiselect({
+			message: 'Select a fruit',
+			options: testOptions,
+			input,
+			output,
+		});
+
+		input.emit('keypress', '', { name: 'left' });
+		input.emit('keypress', '', { name: 'return' });
+		await result;
+		expect(output.buffer).toMatchSnapshot();
+		expect(output.buffer.toString()).toMatch('5 items selected');
+	});
+
+	test('everything is deselected if left is pressed again', async () => {
+		const result = autocompleteMultiselect({
+			message: 'Select a fruit',
+			options: testOptions,
+			input,
+			output,
+		});
+
+		input.emit('keypress', '', { name: 'left' });
+		input.emit('keypress', '', { name: 'left' });
+		input.emit('keypress', '', { name: 'return' });
+		await result;
+		expect(output.buffer).toMatchSnapshot();
+		expect(output.buffer.toString()).toMatch('0 items selected');
+	});
+
+	test('inverse can be selected with right arrow', async () => {
+		const result = autocompleteMultiselect({
+			message: 'Select a fruit',
+			options: testOptions,
+			input,
+			output,
+		});
+
+		input.emit('keypress', '', { name: 'down' });
+		input.emit('keypress', '', { name: 'space' });
+		input.emit('keypress', '', { name: 'right' });
+		input.emit('keypress', '', { name: 'return' });
+		await result;
+		expect(output.buffer).toMatchSnapshot();
+		expect(output.buffer.toString()).toMatch('4 items selected');
+	});
+
+	test('all selection only applies to filtered options', async () => {
+		const result = autocompleteMultiselect({
+			message: 'Select a fruit',
+			options: testOptions,
+			input,
+			output,
+		});
+
+		input.emit('keypress', 'r', { name: 'r' });
+		input.emit('keypress', '', { name: 'left' });
+		input.emit('keypress', '', { name: 'return' });
+		await result;
+		expect(output.buffer).toMatchSnapshot();
+		expect(output.buffer.toString()).toMatch('3 items selected');
+	});
+
+	test('inversion only applies to filtered options', async () => {
+		const result = autocompleteMultiselect({
+			message: 'Select a fruit',
+			options: testOptions,
+			input,
+			output,
+		});
+
+		input.emit('keypress', 'r', { name: 'r' });
+		input.emit('keypress', '', { name: 'down' });
+		input.emit('keypress', '', { name: 'space' });
+		input.emit('keypress', '', { name: 'right' });
+		input.emit('keypress', '', { name: 'return' });
+		await result;
+		expect(output.buffer).toMatchSnapshot();
+		expect(output.buffer.toString()).toMatch('2 items selected');
+	});
 });


### PR DESCRIPTION
This PR adds the ability to select all/inverse items for the `autocompleMultiselect` prompt, using Shift+Up (select all) and Shift+Down (select inverse)


See this (badly) in action here
https://github.com/user-attachments/assets/1a1275c7-51a2-4017-9232-8e8b09b748f5

## Caveats/things that can be changed

- The select all/select inverse behavior only applies to the filtered down list, not the whole list. I thought this would be more predictable.
- This behavior could be an option, but i decided to just do it by default
- When selecting all when everything is selected, everything will be deselected again
- Shift+Up and down were used bc these were the easiest to implement without touching the `prompt` base class. 
	- Initially i wanted to do `ctrl+a` and `ctrl+i`, but `ctrl+i` = `tab` in node readline. 
	- Also relying on the users keyboard layout like that did not seem like a good idea. 
	- I also thought about `[` and `]`, but could not erase those.
	  - there is a check in `Prompt` that erases `_actionKey`s, but that relies on the key having a name, which `[` and `]` do not have
	  - i could do it manually by also writing `ctrl+h` to `Prompt.rl`, but `Prompt.rl` is private.
  - I also tried Left and Right, but could not move the cursor back to the correct spot without access to `Prompt.rl`

Let me know what you think and whether i should change anything!

