### PR TITLE
types: use more accurate type to replace any

### DIFF
--- a/.changeset/rich-plants-call.md
+++ b/.changeset/rich-plants-call.md
@@ -2,4 +2,4 @@
 "@clack/prompts": patch
 ---
 
-types: use more accurate type to replace any
+chore: use more accurate type to replace any in group select

--- a/.changeset/rich-plants-call.md
+++ b/.changeset/rich-plants-call.md
@@ -1,0 +1,5 @@
+---
+"@clack/prompts": patch
+---
+
+types: use more accurate type to replace any

--- a/packages/prompts/src/group-multi-select.ts
+++ b/packages/prompts/src/group-multi-select.ts
@@ -23,7 +23,7 @@ export interface GroupMultiSelectOptions<Value> extends CommonOptions {
 export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) => {
 	const { selectableGroups = true, groupSpacing = 0 } = opts;
 	const opt = (
-		option: Option<Value>,
+		option: Option<Value> & { group: string | boolean },
 		state:
 			| 'inactive'
 			| 'active'
@@ -33,12 +33,12 @@ export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) =>
 			| 'group-active-selected'
 			| 'submitted'
 			| 'cancelled',
-		options: Option<Value>[] = []
+		options: (Option<Value> & { group: string | boolean })[] = []
 	) => {
 		const label = option.label ?? String(option.value);
-		const isItem = typeof (option as any).group === 'string';
+		const isItem = typeof option.group === 'string';
 		const next = isItem && (options[options.indexOf(option) + 1] ?? { group: true });
-		const isLast = isItem && (next as any).group === true;
+		const isLast = isItem && next && next.group === true;
 		const prefix = isItem ? (selectableGroups ? `${isLast ? S_BAR_END : S_BAR} ` : '  ') : '';
 		let spacingPrefix = '';
 		if (groupSpacing > 0 && !isItem) {


### PR DESCRIPTION
@43081j , It is an amazing library and helps me a lot. Thanks for all your work in this repo.

I see we have precise type in this [link](https://github.com/bombshell-dev/clack/blob/main/packages/core/src/prompts/group-multiselect.ts#L12). 

<img width="1706" height="1206" alt="image" src="https://github.com/user-attachments/assets/b3698792-7fff-4bc7-a514-ff3692d3505f" />

So should we use more accurate type to replace `any` in another file? This will make our code clearer. If you have some suggestions for this pr. Please tell me directly. Thanks again.

