### PR TITLE
docs: add import for tasks example

### DIFF
--- a/packages/prompts/README.md
+++ b/packages/prompts/README.md
@@ -203,7 +203,9 @@ console.log(group.name, group.age, group.color);
 Execute multiple tasks in spinners.
 
 ```js
-await p.tasks([
+import { tasks } from '@clack/prompts';
+
+await tasks([
   {
     title: 'Installing via npm',
     task: async (message) => {


### PR DESCRIPTION
The task example doesn't have api import. So I think we should add api import for task example like other examples. 

<img width="1406" height="1220" alt="image" src="https://github.com/user-attachments/assets/bf5d6f9f-4e0a-498b-88d7-237c3f823bd1" />
