### PR TITLE
refactor(progress): remove unnecessary return statement in start func…

### DIFF
--- a/packages/prompts/src/progress-bar.ts
+++ b/packages/prompts/src/progress-bar.ts
@@ -53,7 +53,7 @@ export function progress({
 
 	const start = (msg = '') => {
 		previousMessage = msg;
-		return spin.start(drawProgress('initial', msg));
+		spin.start(drawProgress('initial', msg));
 	};
 	const advance = (step = 1, msg?: string): void => {
 		value = Math.min(max, step + value);


### PR DESCRIPTION
…tion

The return value of `spinner.start` is `undefined`. I think getting this return value is not useful for developers. So can we remove `return` safely ?
