### PR TITLE
docs: add type assert for text validation example

### DIFF
--- a/examples/basic/text-validation.ts
+++ b/examples/basic/text-validation.ts
@@ -9,7 +9,7 @@ async function main() {
 		message: 'Enter your name (letters and spaces only)',
 		initialValue: 'John123', // Invalid initial value with numbers
 		validate: (value) => {
-			if (!/^[a-zA-Z\s]+$/.test(value)) return 'Name can only contain letters and spaces';
+			if (!value || !/^[a-zA-Z\s]+$/.test(value)) return 'Name can only contain letters and spaces';
 			return undefined;
 		},
 	});
@@ -25,7 +25,7 @@ async function main() {
 		message: 'Enter another name (letters and spaces only)',
 		initialValue: 'John Doe', // Valid initial value
 		validate: (value) => {
-			if (!/^[a-zA-Z\s]+$/.test(value)) return 'Name can only contain letters and spaces';
+			if (!value || !/^[a-zA-Z\s]+$/.test(value)) return 'Name can only contain letters and spaces';
 			return undefined;
 		},
 	});


### PR DESCRIPTION
The type of `value` should be `string`,  maybe we can add type assert to pass this type check.

<img width="1413" height="437" alt="image" src="https://github.com/user-attachments/assets/50147c3e-08de-49f9-a753-6e5a32d1cccf" />
