### PR TITLE
fix: allow non-writestream writables to have columns

### DIFF
--- a/.changeset/tough-crews-flow.md
+++ b/.changeset/tough-crews-flow.md
@@ -1,0 +1,6 @@
+---
+"@clack/prompts": patch
+"@clack/core": patch
+---
+
+Allow custom writables as output stream.

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -2,7 +2,7 @@ import { stdin, stdout } from 'node:process';
 import type { Key } from 'node:readline';
 import * as readline from 'node:readline';
 import type { Readable, Writable } from 'node:stream';
-import { ReadStream, WriteStream } from 'node:tty';
+import { ReadStream } from 'node:tty';
 import { cursor } from 'sisteransi';
 import { isActionKey } from './settings.js';
 
@@ -84,8 +84,9 @@ export function block({
 }
 
 export const getColumns = (output: Writable): number => {
-	if (output instanceof WriteStream && output.columns) {
-		return output.columns;
+	const withColumns = output as Writable & { columns?: number };
+	if ('columns' in withColumns && typeof withColumns.columns === 'number') {
+		return withColumns.columns;
 	}
 	return 80;
 };

--- a/packages/prompts/test/note.test.ts
+++ b/packages/prompts/test/note.test.ts
@@ -68,7 +68,7 @@ describe.each(['true', 'false'])('note (isCI = %s)', (isCI) => {
 		const message = `${'test string '.repeat(32)}\n`.repeat(4).trim();
 		prompts.note(message, 'title', {
 			input,
-			output: Object.assign(output, { columns: 75 }),
+			output,
 		});
 
 		expect(output.buffer).toMatchSnapshot();
@@ -79,7 +79,7 @@ describe.each(['true', 'false'])('note (isCI = %s)', (isCI) => {
 		prompts.note(message, 'title', {
 			format: (line) => colors.red(`* ${colors.cyan(line)} *`),
 			input,
-			output: Object.assign(output, { columns: 75 }),
+			output,
 		});
 
 		expect(output.buffer).toMatchSnapshot();

--- a/packages/prompts/test/test-utils.ts
+++ b/packages/prompts/test/test-utils.ts
@@ -3,6 +3,7 @@ import { Readable, Writable } from 'node:stream';
 export class MockWritable extends Writable {
 	public buffer: string[] = [];
 	public isTTY = false;
+	public columns = 80;
 
 	_write(
 		chunk: any,


### PR DESCRIPTION
Mostly for tests, so we can set the `columns`.

Previously, the `Object.assign` in tests was no-op as we'd always return
`80`.
