### PR TITLE
feat: add `clearPromptOnDone` for some prompts

### DIFF
--- a/packages/prompts/src/autocomplete.ts
+++ b/packages/prompts/src/autocomplete.ts
@@ -1,8 +1,9 @@
 import { AutocompletePrompt } from '@clack/core';
 import color from 'picocolors';
-import { cursor } from "sisteransi";
+import { cursor } from 'sisteransi';
 import {
 	type CommonPromptOptions,
+	clearPrompt,
 	S_BAR,
 	S_BAR_END,
 	S_CHECKBOX_INACTIVE,
@@ -10,7 +11,6 @@ import {
 	S_RADIO_ACTIVE,
 	S_RADIO_INACTIVE,
 	symbol,
-	clearPrompt,
 } from './common.js';
 import { limitOptions } from './limit-options.js';
 import type { Option } from './select.js';
@@ -106,7 +106,9 @@ export const autocomplete = <Value>(opts: AutocompleteOptions<Value>) => {
 					const label =
 						selected.length > 0 ? `  ${color.dim(selected.map(getLabel).join(', '))}` : '';
 
-					return clearPrompt(opts) ? cursor.up() :`${headings.join('\n')}\n${color.gray(S_BAR)}${label}`;
+					return clearPrompt(opts)
+						? cursor.up()
+						: `${headings.join('\n')}\n${color.gray(S_BAR)}${label}`;
 				}
 
 				case 'cancel': {
@@ -279,7 +281,9 @@ export const autocompleteMultiselect = <Value>(opts: AutocompleteMultiSelectOpti
 			// Render prompt state
 			switch (this.state) {
 				case 'submit': {
-					return clearPrompt(opts) ? cursor.up() : `${title}${color.gray(S_BAR)}  ${color.dim(`${this.selectedValues.length} items selected`)}`;
+					return clearPrompt(opts)
+						? cursor.up()
+						: `${title}${color.gray(S_BAR)}  ${color.dim(`${this.selectedValues.length} items selected`)}`;
 				}
 				case 'cancel': {
 					return `${title}${color.gray(S_BAR)}  ${color.strikethrough(color.dim(userInput))}`;

--- a/packages/prompts/src/autocomplete.ts
+++ b/packages/prompts/src/autocomplete.ts
@@ -1,7 +1,8 @@
 import { AutocompletePrompt } from '@clack/core';
 import color from 'picocolors';
+import { cursor } from "sisteransi";
 import {
-	type CommonOptions,
+	type CommonPromptOptions,
 	S_BAR,
 	S_BAR_END,
 	S_CHECKBOX_INACTIVE,
@@ -9,6 +10,7 @@ import {
 	S_RADIO_ACTIVE,
 	S_RADIO_INACTIVE,
 	symbol,
+	clearPrompt,
 } from './common.js';
 import { limitOptions } from './limit-options.js';
 import type { Option } from './select.js';
@@ -41,7 +43,7 @@ function getSelectedOptions<T>(values: T[], options: Option<T>[]): Option<T>[] {
 	return results;
 }
 
-interface AutocompleteSharedOptions<Value> extends CommonOptions {
+interface AutocompleteSharedOptions<Value> extends CommonPromptOptions {
 	/**
 	 * The message to display to the user.
 	 */
@@ -103,7 +105,7 @@ export const autocomplete = <Value>(opts: AutocompleteOptions<Value>) => {
 					const selected = getSelectedOptions(this.selectedValues, options);
 					const label =
 						selected.length > 0 ? `  ${color.dim(selected.map(getLabel).join(', '))}` : '';
-					return `${title}${color.gray(S_BAR)}${label}`;
+					return clearPrompt(opts) ? cursor.up() : `${title}${color.gray(S_BAR)}${label}`;
 				}
 
 				case 'cancel': {
@@ -266,7 +268,7 @@ export const autocompleteMultiselect = <Value>(opts: AutocompleteMultiSelectOpti
 			// Render prompt state
 			switch (this.state) {
 				case 'submit': {
-					return `${title}${color.gray(S_BAR)}  ${color.dim(`${this.selectedValues.length} items selected`)}`;
+					return clearPrompt(opts) ? cursor.up() : `${title}${color.gray(S_BAR)}  ${color.dim(`${this.selectedValues.length} items selected`)}`;
 				}
 				case 'cancel': {
 					return `${title}${color.gray(S_BAR)}  ${color.strikethrough(color.dim(userInput))}`;

--- a/packages/prompts/src/common.ts
+++ b/packages/prompts/src/common.ts
@@ -64,5 +64,5 @@ export interface CommonPromptOptions extends CommonOptions {
 }
 
 export const clearPrompt = (opts: CommonPromptOptions) => {
-	return opts.clearPromptOnDone && typeof opts.clearPromptOnDone === 'boolean';
+	return Boolean(opts.clearPromptOnDone && typeof opts.clearPromptOnDone === 'boolean');
 }

--- a/packages/prompts/src/common.ts
+++ b/packages/prompts/src/common.ts
@@ -60,7 +60,7 @@ export interface CommonOptions {
 }
 
 export interface CommonPromptOptions extends CommonOptions {
-	clearPromptOnDone: boolean;
+	clearPromptOnDone?: boolean;
 }
 
 export const clearPrompt = (opts: CommonPromptOptions) => {

--- a/packages/prompts/src/common.ts
+++ b/packages/prompts/src/common.ts
@@ -65,4 +65,4 @@ export interface CommonPromptOptions extends CommonOptions {
 
 export const clearPrompt = (opts: CommonPromptOptions) => {
 	return Boolean(opts.clearPromptOnDone && typeof opts.clearPromptOnDone === 'boolean');
-}
+};

--- a/packages/prompts/src/common.ts
+++ b/packages/prompts/src/common.ts
@@ -58,3 +58,11 @@ export interface CommonOptions {
 	output?: Writable;
 	signal?: AbortSignal;
 }
+
+export interface CommonPromptOptions extends CommonOptions {
+	clearPromptOnDone: boolean;
+}
+
+export const clearPrompt = (opts: CommonPromptOptions) => {
+	return opts.clearPromptOnDone && typeof opts.clearPromptOnDone === 'boolean';
+}

--- a/packages/prompts/src/confirm.ts
+++ b/packages/prompts/src/confirm.ts
@@ -1,14 +1,14 @@
 import { ConfirmPrompt } from '@clack/core';
 import color from 'picocolors';
-import { cursor } from "sisteransi";
+import { cursor } from 'sisteransi';
 import {
 	type CommonPromptOptions,
+	clearPrompt,
 	S_BAR,
 	S_BAR_END,
 	S_RADIO_ACTIVE,
 	S_RADIO_INACTIVE,
 	symbol,
-	clearPrompt,
 } from './common.js';
 
 export interface ConfirmOptions extends CommonPromptOptions {
@@ -33,7 +33,9 @@ export const confirm = (opts: ConfirmOptions) => {
 
 			switch (this.state) {
 				case 'submit':
-					return clearPrompt(opts) ? cursor.up() : `${title}${color.gray(S_BAR)}  ${color.dim(value)}`;
+					return clearPrompt(opts)
+						? cursor.up()
+						: `${title}${color.gray(S_BAR)}  ${color.dim(value)}`;
 				case 'cancel':
 					return `${title}${color.gray(S_BAR)}  ${color.strikethrough(
 						color.dim(value)

--- a/packages/prompts/src/confirm.ts
+++ b/packages/prompts/src/confirm.ts
@@ -1,15 +1,17 @@
 import { ConfirmPrompt } from '@clack/core';
 import color from 'picocolors';
+import { cursor } from "sisteransi";
 import {
-	type CommonOptions,
+	type CommonPromptOptions,
 	S_BAR,
 	S_BAR_END,
 	S_RADIO_ACTIVE,
 	S_RADIO_INACTIVE,
 	symbol,
+	clearPrompt,
 } from './common.js';
 
-export interface ConfirmOptions extends CommonOptions {
+export interface ConfirmOptions extends CommonPromptOptions {
 	message: string;
 	active?: string;
 	inactive?: string;
@@ -31,7 +33,7 @@ export const confirm = (opts: ConfirmOptions) => {
 
 			switch (this.state) {
 				case 'submit':
-					return `${title}${color.gray(S_BAR)}  ${color.dim(value)}`;
+					return clearPrompt(opts) ? cursor.up() : `${title}${color.gray(S_BAR)}  ${color.dim(value)}`;
 				case 'cancel':
 					return `${title}${color.gray(S_BAR)}  ${color.strikethrough(
 						color.dim(value)

--- a/packages/prompts/src/group-multi-select.ts
+++ b/packages/prompts/src/group-multi-select.ts
@@ -1,15 +1,15 @@
 import { GroupMultiSelectPrompt } from '@clack/core';
 import color from 'picocolors';
-import { cursor } from "sisteransi";
+import { cursor } from 'sisteransi';
 import {
 	type CommonPromptOptions,
+	clearPrompt,
 	S_BAR,
 	S_BAR_END,
 	S_CHECKBOX_ACTIVE,
 	S_CHECKBOX_INACTIVE,
 	S_CHECKBOX_SELECTED,
 	symbol,
-	clearPrompt,
 } from './common.js';
 import type { Option } from './select.js';
 

--- a/packages/prompts/src/group-multi-select.ts
+++ b/packages/prompts/src/group-multi-select.ts
@@ -1,17 +1,19 @@
 import { GroupMultiSelectPrompt } from '@clack/core';
 import color from 'picocolors';
+import { cursor } from "sisteransi";
 import {
-	type CommonOptions,
+	type CommonPromptOptions,
 	S_BAR,
 	S_BAR_END,
 	S_CHECKBOX_ACTIVE,
 	S_CHECKBOX_INACTIVE,
 	S_CHECKBOX_SELECTED,
 	symbol,
+	clearPrompt,
 } from './common.js';
 import type { Option } from './select.js';
 
-export interface GroupMultiSelectOptions<Value> extends CommonOptions {
+export interface GroupMultiSelectOptions<Value> extends CommonPromptOptions {
 	message: string;
 	options: Record<string, Option<Value>[]>;
 	initialValues?: Value[];
@@ -109,7 +111,7 @@ export const groupMultiselect = <Value>(opts: GroupMultiSelectOptions<Value>) =>
 						.map((option) => opt(option, 'submitted'));
 					const optionsText =
 						selectedOptions.length === 0 ? '' : `  ${selectedOptions.join(color.dim(', '))}`;
-					return `${title}${color.gray(S_BAR)}${optionsText}`;
+					return clearPrompt(opts) ? cursor.up() : `${title}${color.gray(S_BAR)}${optionsText}`;
 				}
 				case 'cancel': {
 					const label = this.options

--- a/packages/prompts/src/multi-select.ts
+++ b/packages/prompts/src/multi-select.ts
@@ -1,15 +1,15 @@
 import { MultiSelectPrompt } from '@clack/core';
 import color from 'picocolors';
-import { cursor } from "sisteransi";
+import { cursor } from 'sisteransi';
 import {
 	type CommonPromptOptions,
+	clearPrompt,
 	S_BAR,
 	S_BAR_END,
 	S_CHECKBOX_ACTIVE,
 	S_CHECKBOX_INACTIVE,
 	S_CHECKBOX_SELECTED,
 	symbol,
-	clearPrompt,
 } from './common.js';
 import { limitOptions } from './limit-options.js';
 import type { Option } from './select.js';
@@ -88,12 +88,14 @@ export const multiselect = <Value>(opts: MultiSelectOptions<Value>) => {
 
 			switch (this.state) {
 				case 'submit': {
-					return clearPrompt(opts) ? cursor.up() : `${title}${color.gray(S_BAR)}  ${
-						this.options
-							.filter(({ value: optionValue }) => value.includes(optionValue))
-							.map((option) => opt(option, 'submitted'))
-							.join(color.dim(', ')) || color.dim('none')
-					}`;
+					return clearPrompt(opts)
+						? cursor.up()
+						: `${title}${color.gray(S_BAR)}  ${
+								this.options
+									.filter(({ value: optionValue }) => value.includes(optionValue))
+									.map((option) => opt(option, 'submitted'))
+									.join(color.dim(', ')) || color.dim('none')
+							}`;
 				}
 				case 'cancel': {
 					const label = this.options

--- a/packages/prompts/src/multi-select.ts
+++ b/packages/prompts/src/multi-select.ts
@@ -1,18 +1,20 @@
 import { MultiSelectPrompt } from '@clack/core';
 import color from 'picocolors';
+import { cursor } from "sisteransi";
 import {
-	type CommonOptions,
+	type CommonPromptOptions,
 	S_BAR,
 	S_BAR_END,
 	S_CHECKBOX_ACTIVE,
 	S_CHECKBOX_INACTIVE,
 	S_CHECKBOX_SELECTED,
 	symbol,
+	clearPrompt,
 } from './common.js';
 import { limitOptions } from './limit-options.js';
 import type { Option } from './select.js';
 
-export interface MultiSelectOptions<Value> extends CommonOptions {
+export interface MultiSelectOptions<Value> extends CommonPromptOptions {
 	message: string;
 	options: Option<Value>[];
 	initialValues?: Value[];
@@ -86,7 +88,7 @@ export const multiselect = <Value>(opts: MultiSelectOptions<Value>) => {
 
 			switch (this.state) {
 				case 'submit': {
-					return `${title}${color.gray(S_BAR)}  ${
+					return clearPrompt(opts) ? cursor.up() : `${title}${color.gray(S_BAR)}  ${
 						this.options
 							.filter(({ value: optionValue }) => value.includes(optionValue))
 							.map((option) => opt(option, 'submitted'))

--- a/packages/prompts/src/password.ts
+++ b/packages/prompts/src/password.ts
@@ -1,7 +1,14 @@
 import { PasswordPrompt } from '@clack/core';
 import color from 'picocolors';
-import { cursor } from "sisteransi";
-import { type CommonPromptOptions, S_BAR, S_BAR_END, S_PASSWORD_MASK, symbol, clearPrompt } from './common.js';
+import { cursor } from 'sisteransi';
+import {
+	type CommonPromptOptions,
+	clearPrompt,
+	S_BAR,
+	S_BAR_END,
+	S_PASSWORD_MASK,
+	symbol,
+} from './common.js';
 
 export interface PasswordOptions extends CommonPromptOptions {
 	message: string;

--- a/packages/prompts/src/password.ts
+++ b/packages/prompts/src/password.ts
@@ -1,8 +1,9 @@
 import { PasswordPrompt } from '@clack/core';
 import color from 'picocolors';
-import { type CommonOptions, S_BAR, S_BAR_END, S_PASSWORD_MASK, symbol } from './common.js';
+import { cursor } from "sisteransi";
+import { type CommonPromptOptions, S_BAR, S_BAR_END, S_PASSWORD_MASK, symbol, clearPrompt } from './common.js';
 
-export interface PasswordOptions extends CommonOptions {
+export interface PasswordOptions extends CommonPromptOptions {
 	message: string;
 	mask?: string;
 	validate?: (value: string | undefined) => string | Error | undefined;
@@ -32,7 +33,7 @@ export const password = (opts: PasswordOptions) => {
 				}
 				case 'submit': {
 					const maskedText = masked ? `  ${color.dim(masked)}` : '';
-					return `${title}${color.gray(S_BAR)}${maskedText}`;
+					return clearPrompt(opts) ? cursor.up() : `${title}${color.gray(S_BAR)}${maskedText}`;
 				}
 				case 'cancel': {
 					const maskedText = masked ? `  ${color.strikethrough(color.dim(masked))}` : '';

--- a/packages/prompts/src/path.ts
+++ b/packages/prompts/src/path.ts
@@ -1,9 +1,9 @@
 import { existsSync, lstatSync, readdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { autocomplete } from './autocomplete.js';
-import type { CommonOptions } from './common.js';
+import type { CommonPromptOptions } from './common.js';
 
-export interface PathOptions extends CommonOptions {
+export interface PathOptions extends CommonPromptOptions {
 	root?: string;
 	directory?: boolean;
 	initialValue?: string;

--- a/packages/prompts/src/select-key.ts
+++ b/packages/prompts/src/select-key.ts
@@ -1,7 +1,7 @@
 import { SelectKeyPrompt } from '@clack/core';
 import color from 'picocolors';
 import { cursor } from 'sisteransi';
-import { S_BAR, S_BAR_END, symbol, clearPrompt } from './common.js';
+import { clearPrompt, S_BAR, S_BAR_END, symbol } from './common.js';
 import type { Option, SelectOptions } from './select.js';
 
 export const selectKey = <Value extends string>(opts: SelectOptions<Value>) => {
@@ -37,10 +37,12 @@ export const selectKey = <Value extends string>(opts: SelectOptions<Value>) => {
 
 			switch (this.state) {
 				case 'submit':
-					return clearPrompt(opts) ? cursor.up() : `${title}${color.gray(S_BAR)}  ${opt(
-						this.options.find((opt) => opt.value === this.value) ?? opts.options[0],
-						'selected'
-					)}`;
+					return clearPrompt(opts)
+						? cursor.up()
+						: `${title}${color.gray(S_BAR)}  ${opt(
+								this.options.find((opt) => opt.value === this.value) ?? opts.options[0],
+								'selected'
+							)}`;
 				case 'cancel':
 					return `${title}${color.gray(S_BAR)}  ${opt(this.options[0], 'cancelled')}\n${color.gray(
 						S_BAR

--- a/packages/prompts/src/select-key.ts
+++ b/packages/prompts/src/select-key.ts
@@ -1,6 +1,7 @@
 import { SelectKeyPrompt } from '@clack/core';
 import color from 'picocolors';
-import { S_BAR, S_BAR_END, symbol } from './common.js';
+import { cursor } from 'sisteransi';
+import { S_BAR, S_BAR_END, symbol, clearPrompt } from './common.js';
 import type { Option, SelectOptions } from './select.js';
 
 export const selectKey = <Value extends string>(opts: SelectOptions<Value>) => {
@@ -36,7 +37,7 @@ export const selectKey = <Value extends string>(opts: SelectOptions<Value>) => {
 
 			switch (this.state) {
 				case 'submit':
-					return `${title}${color.gray(S_BAR)}  ${opt(
+					return clearPrompt(opts) ? cursor.up() : `${title}${color.gray(S_BAR)}  ${opt(
 						this.options.find((opt) => opt.value === this.value) ?? opts.options[0],
 						'selected'
 					)}`;

--- a/packages/prompts/src/select.ts
+++ b/packages/prompts/src/select.ts
@@ -1,12 +1,14 @@
 import { SelectPrompt } from '@clack/core';
 import color from 'picocolors';
+import { cursor } from 'sisteransi';
 import {
-	type CommonOptions,
+	type CommonPromptOptions,
 	S_BAR,
 	S_BAR_END,
 	S_RADIO_ACTIVE,
 	S_RADIO_INACTIVE,
 	symbol,
+	clearPrompt
 } from './common.js';
 import { limitOptions } from './limit-options.js';
 
@@ -50,7 +52,7 @@ export type Option<Value> = Value extends Primitive
 			hint?: string;
 		};
 
-export interface SelectOptions<Value> extends CommonOptions {
+export interface SelectOptions<Value> extends CommonPromptOptions {
 	message: string;
 	options: Option<Value>[];
 	initialValue?: Value;
@@ -85,7 +87,7 @@ export const select = <Value>(opts: SelectOptions<Value>) => {
 
 			switch (this.state) {
 				case 'submit':
-					return `${title}${color.gray(S_BAR)}  ${opt(this.options[this.cursor], 'selected')}`;
+					return clearPrompt(opts) ? cursor.up() : `${title}${color.gray(S_BAR)}  ${opt(this.options[this.cursor], 'selected')}`;
 				case 'cancel':
 					return `${title}${color.gray(S_BAR)}  ${opt(
 						this.options[this.cursor],

--- a/packages/prompts/src/select.ts
+++ b/packages/prompts/src/select.ts
@@ -3,12 +3,12 @@ import color from 'picocolors';
 import { cursor } from 'sisteransi';
 import {
 	type CommonPromptOptions,
+	clearPrompt,
 	S_BAR,
 	S_BAR_END,
 	S_RADIO_ACTIVE,
 	S_RADIO_INACTIVE,
 	symbol,
-	clearPrompt
 } from './common.js';
 import { limitOptions } from './limit-options.js';
 
@@ -87,7 +87,9 @@ export const select = <Value>(opts: SelectOptions<Value>) => {
 
 			switch (this.state) {
 				case 'submit':
-					return clearPrompt(opts) ? cursor.up() : `${title}${color.gray(S_BAR)}  ${opt(this.options[this.cursor], 'selected')}`;
+					return clearPrompt(opts)
+						? cursor.up()
+						: `${title}${color.gray(S_BAR)}  ${opt(this.options[this.cursor], 'selected')}`;
 				case 'cancel':
 					return `${title}${color.gray(S_BAR)}  ${opt(
 						this.options[this.cursor],

--- a/packages/prompts/src/text.ts
+++ b/packages/prompts/src/text.ts
@@ -1,7 +1,7 @@
 import { TextPrompt } from '@clack/core';
 import color from 'picocolors';
-import { cursor } from "sisteransi";
-import { type CommonPromptOptions, S_BAR, S_BAR_END, symbol, clearPrompt } from './common.js';
+import { cursor } from 'sisteransi';
+import { type CommonPromptOptions, clearPrompt, S_BAR, S_BAR_END, symbol } from './common.js';
 
 export interface TextOptions extends CommonPromptOptions {
 	message: string;

--- a/packages/prompts/src/text.ts
+++ b/packages/prompts/src/text.ts
@@ -1,8 +1,9 @@
 import { TextPrompt } from '@clack/core';
 import color from 'picocolors';
-import { type CommonOptions, S_BAR, S_BAR_END, symbol } from './common.js';
+import { cursor } from "sisteransi";
+import { type CommonPromptOptions, S_BAR, S_BAR_END, symbol, clearPrompt } from './common.js';
 
-export interface TextOptions extends CommonOptions {
+export interface TextOptions extends CommonPromptOptions {
 	message: string;
 	placeholder?: string;
 	defaultValue?: string;
@@ -36,7 +37,7 @@ export const text = (opts: TextOptions) => {
 				}
 				case 'submit': {
 					const valueText = value ? `  ${color.dim(value)}` : '';
-					return `${title}${color.gray(S_BAR)}${valueText}`;
+					return clearPrompt(opts) ? cursor.up() : `${title}${color.gray(S_BAR)}${valueText}`;
 				}
 				case 'cancel': {
 					const valueText = value ? `  ${color.strikethrough(color.dim(value))}` : '';

--- a/packages/prompts/test/__snapshots__/autocomplete.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/autocomplete.test.ts.snap
@@ -20,6 +20,41 @@ exports[`autocomplete > can be aborted by a signal 1`] = `
 ]
 `;
 
+exports[`autocomplete > clear prompt after done 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m
+[36m│[39m  [2mSearch:[22m [7m[8m_[28m[27m
+[36m│[39m  [32m●[39m Apple
+[36m│[39m  [2m○[22m [2mBanana[22m
+[36m│[39m  [2m○[22m [2mCherry[22m
+[36m│[39m  [2m○[22m [2mGrape[22m
+[36m│[39m  [2m○[22m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=10>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2mSearch:[22m
+[36m│[39m  [2m○[22m [2mApple[22m
+[36m│[39m  [32m●[39m Banana
+[36m│[39m  [2m○[22m [2mCherry[22m
+[36m│[39m  [2m○[22m [2mGrape[22m
+[36m│[39m  [2m○[22m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=10>",
+  "",
+  "<erase.down>",
+  "<cursor.up count=1>",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
 exports[`autocomplete > limits displayed options when maxItems is set 1`] = `
 [
   "<cursor.hide>",
@@ -355,6 +390,60 @@ exports[`autocompleteMultiselect > can use navigation keys to select options 1`]
   "<erase.down>",
   "[32m◇[39m  Select fruits
 [90m│[39m  [2m2 items selected[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`autocompleteMultiselect > clear prompt after done 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  Select fruits
+
+[36m│[39m  [2mSearch:[22m [7m[8m_[28m[27m
+[36m│[39m  [2m◻[22m Apple
+[36m│[39m  [2m◻[22m [2mBanana[22m
+[36m│[39m  [2m◻[22m [2mCherry[22m
+[36m│[39m  [2m◻[22m [2mGrape[22m
+[36m│[39m  [2m◻[22m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mTab:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=10>",
+  "<cursor.down count=3>",
+  "<erase.down>",
+  "[36m│[39m  [2mSearch:[22m [2m[22m
+[36m│[39m  [2m◻[22m [2mApple[22m
+[36m│[39m  [2m◻[22m Banana
+[36m│[39m  [2m◻[22m [2mCherry[22m
+[36m│[39m  [2m◻[22m [2mGrape[22m
+[36m│[39m  [2m◻[22m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mSpace/Tab:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=10>",
+  "<cursor.down count=5>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  [32m◼[39m Banana",
+  "<cursor.down count=5>",
+  "<cursor.backward count=999><cursor.up count=10>",
+  "<cursor.down count=5>",
+  "<erase.down>",
+  "[36m│[39m  [32m◼[39m [2mBanana[22m
+[36m│[39m  [2m◻[22m Cherry
+[36m│[39m  [2m◻[22m [2mGrape[22m
+[36m│[39m  [2m◻[22m [2mOrange[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to navigate • [2mSpace/Tab:[22m[2m select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=10>",
+  "<cursor.down count=6>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  [32m◼[39m Cherry",
+  "<cursor.down count=4>",
+  "<cursor.backward count=999><cursor.up count=10>",
+  "",
+  "<erase.down>",
+  "<cursor.up count=1>",
   "
 ",
   "<cursor.show>",

--- a/packages/prompts/test/__snapshots__/confirm.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/confirm.test.ts.snap
@@ -53,6 +53,24 @@ exports[`confirm (isCI = false) > can set initialValue 1`] = `
 ]
 `;
 
+exports[`confirm (isCI = false) > clear prompt after done 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [32m●[39m Yes [2m/[22m [2m○[22m [2mNo[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=4>",
+  "",
+  "<erase.down>",
+  "<cursor.up count=1>",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
 exports[`confirm (isCI = false) > left arrow moves to previous choice 1`] = `
 [
   "<cursor.hide>",
@@ -210,6 +228,24 @@ exports[`confirm (isCI = true) > can set initialValue 1`] = `
   "<erase.down>",
   "[32m◇[39m  foo
 [90m│[39m  [2mNo[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`confirm (isCI = true) > clear prompt after done 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [32m●[39m Yes [2m/[22m [2m○[22m [2mNo[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=4>",
+  "",
+  "<erase.down>",
+  "<cursor.up count=1>",
   "
 ",
   "<cursor.show>",

--- a/packages/prompts/test/__snapshots__/group-multi-select.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/group-multi-select.test.ts.snap
@@ -222,6 +222,43 @@ exports[`groupMultiselect (isCI = false) > can submit empty selection when requi
 ]
 `;
 
+exports[`groupMultiselect (isCI = false) > clear prompt after done 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [2m[22m[36m◻[39m group1
+[36m│[39m  │ [36m◻[39m [2mgroup1value0[22m
+[36m│[39m  └ [36m◻[39m [2mgroup1value1[22m
+[36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup2value0[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=8>",
+  "<cursor.down count=2>",
+  "<erase.down>",
+  "[36m│[39m  [2m[22m[2m◻[22m [2mgroup1[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group1value0
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup1value1[22m
+[36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup2value0[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=8>",
+  "<cursor.down count=3>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  [2m│ [22m[32m◼[39m group1value0",
+  "<cursor.down count=5>",
+  "<cursor.backward count=999><cursor.up count=8>",
+  "",
+  "<erase.down>",
+  "<cursor.up count=1>",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
 exports[`groupMultiselect (isCI = false) > cursorAt sets initial selection 1`] = `
 [
   "<cursor.hide>",
@@ -754,6 +791,43 @@ exports[`groupMultiselect (isCI = true) > can submit empty selection when requir
   "<erase.down>",
   "[32m◇[39m  foo
 [90m│[39m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`groupMultiselect (isCI = true) > clear prompt after done 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [2m[22m[36m◻[39m group1
+[36m│[39m  │ [36m◻[39m [2mgroup1value0[22m
+[36m│[39m  └ [36m◻[39m [2mgroup1value1[22m
+[36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup2value0[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=8>",
+  "<cursor.down count=2>",
+  "<erase.down>",
+  "[36m│[39m  [2m[22m[2m◻[22m [2mgroup1[22m
+[36m│[39m  [2m│ [22m[36m◻[39m group1value0
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup1value1[22m
+[36m│[39m  [2m[22m[2m◻[22m [2mgroup2[22m
+[36m│[39m  [2m└ [22m[2m◻[22m [2mgroup2value0[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=8>",
+  "<cursor.down count=3>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  [2m│ [22m[32m◼[39m group1value0",
+  "<cursor.down count=5>",
+  "<cursor.backward count=999><cursor.up count=8>",
+  "",
+  "<erase.down>",
+  "<cursor.up count=1>",
   "
 ",
   "<cursor.show>",

--- a/packages/prompts/test/__snapshots__/multi-select.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/multi-select.test.ts.snap
@@ -150,6 +150,30 @@ exports[`multiselect (isCI = false) > can submit without selection when required
 ]
 `;
 
+exports[`multiselect (isCI = false) > clear prompt after done 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [36m◻[39m opt0
+[36m│[39m  [2m◻[22m [2mopt1[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=5>",
+  "<cursor.down count=2>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  [32m◼[39m opt0",
+  "<cursor.down count=3>",
+  "<cursor.backward count=999><cursor.up count=5>",
+  "",
+  "<erase.down>",
+  "<cursor.up count=1>",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
 exports[`multiselect (isCI = false) > maxItems renders a sliding window 1`] = `
 [
   "<cursor.hide>",
@@ -754,6 +778,30 @@ exports[`multiselect (isCI = true) > can submit without selection when required 
   "<erase.down>",
   "[32m◇[39m  foo
 [90m│[39m  [2mnone[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`multiselect (isCI = true) > clear prompt after done 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [36m◻[39m opt0
+[36m│[39m  [2m◻[22m [2mopt1[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=5>",
+  "<cursor.down count=2>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  [32m◼[39m opt0",
+  "<cursor.down count=3>",
+  "<cursor.backward count=999><cursor.up count=5>",
+  "",
+  "<erase.down>",
+  "<cursor.up count=1>",
   "
 ",
   "<cursor.show>",

--- a/packages/prompts/test/__snapshots__/password.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/password.test.ts.snap
@@ -14,6 +14,34 @@ exports[`password (isCI = false) > can be aborted by a signal 1`] = `
 ]
 `;
 
+exports[`password (isCI = false) > clear prompt after done 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [7m[8m_[28m[27m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=4>",
+  "<cursor.down count=2>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  ▪[7m[8m_[28m[27m",
+  "<cursor.down count=2>",
+  "<cursor.backward count=999><cursor.up count=4>",
+  "<cursor.down count=2>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  ▪▪[7m[8m_[28m[27m",
+  "<cursor.down count=2>",
+  "<cursor.backward count=999><cursor.up count=4>",
+  "",
+  "<erase.down>",
+  "<cursor.up count=1>",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
 exports[`password (isCI = false) > clears input on error when clearOnError is true 1`] = `
 [
   "<cursor.hide>",
@@ -205,6 +233,34 @@ exports[`password (isCI = true) > can be aborted by a signal 1`] = `
 [36m│[39m  [7m[8m_[28m[27m
 [36m└[39m
 ",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`password (isCI = true) > clear prompt after done 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [7m[8m_[28m[27m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=4>",
+  "<cursor.down count=2>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  ▪[7m[8m_[28m[27m",
+  "<cursor.down count=2>",
+  "<cursor.backward count=999><cursor.up count=4>",
+  "<cursor.down count=2>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  ▪▪[7m[8m_[28m[27m",
+  "<cursor.down count=2>",
+  "<cursor.backward count=999><cursor.up count=4>",
+  "",
+  "<erase.down>",
+  "<cursor.up count=1>",
   "
 ",
   "<cursor.show>",

--- a/packages/prompts/test/__snapshots__/path.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/path.test.ts.snap
@@ -78,6 +78,27 @@ exports[`text (isCI = false) > cannot submit unknown value 1`] = `
 ]
 `;
 
+exports[`text (isCI = false) > clear prompt after done 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m
+[36m│[39m  [2mSearch:[22m /tmp/█
+[36m│[39m  [32m●[39m /tmp/bar
+[36m│[39m  [2m○[22m [2m/tmp/root.zip[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=7>",
+  "",
+  "<erase.down>",
+  "<cursor.up count=1>",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
 exports[`text (isCI = false) > initialValue sets the value 1`] = `
 [
   "<cursor.hide>",
@@ -373,6 +394,27 @@ exports[`text (isCI = true) > cannot submit unknown value 1`] = `
   "<erase.down>",
   "[32m◇[39m  foo
 [90m│[39m  [2m/tmp/bar[22m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`text (isCI = true) > clear prompt after done 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m
+[36m│[39m  [2mSearch:[22m /tmp/█
+[36m│[39m  [32m●[39m /tmp/bar
+[36m│[39m  [2m○[22m [2m/tmp/root.zip[22m
+[36m│[39m  [2m[2m↑/↓[22m[2m to select • [2mEnter:[22m[2m confirm • [2mType:[22m[2m to search[22m
+[36m└[39m",
+  "<cursor.backward count=999><cursor.up count=7>",
+  "",
+  "<erase.down>",
+  "<cursor.up count=1>",
   "
 ",
   "<cursor.show>",

--- a/packages/prompts/test/__snapshots__/select.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/select.test.ts.snap
@@ -36,6 +36,25 @@ exports[`select (isCI = false) > can cancel 1`] = `
 ]
 `;
 
+exports[`select (isCI = false) > clear prompt after done 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [32m●[39m opt0
+[36m│[39m  [2m○[22m [2mopt1[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=5>",
+  "",
+  "<erase.down>",
+  "<cursor.up count=1>",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
 exports[`select (isCI = false) > down arrow selects next option 1`] = `
 [
   "<cursor.hide>",
@@ -187,6 +206,25 @@ exports[`select (isCI = true) > can cancel 1`] = `
   "[31m■[39m  foo
 [90m│[39m  [9m[2mopt0[22m[29m
 [90m│[39m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`select (isCI = true) > clear prompt after done 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [32m●[39m opt0
+[36m│[39m  [2m○[22m [2mopt1[22m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=5>",
+  "",
+  "<erase.down>",
+  "<cursor.up count=1>",
   "
 ",
   "<cursor.show>",

--- a/packages/prompts/test/__snapshots__/text.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/text.test.ts.snap
@@ -33,6 +33,34 @@ exports[`text (isCI = false) > can cancel 1`] = `
 ]
 `;
 
+exports[`text (isCI = false) > clear prompt after done 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [7m[8m_[28m[27m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=4>",
+  "<cursor.down count=2>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  x█",
+  "<cursor.down count=2>",
+  "<cursor.backward count=999><cursor.up count=4>",
+  "<cursor.down count=2>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  xy█",
+  "<cursor.down count=2>",
+  "<cursor.backward count=999><cursor.up count=4>",
+  "",
+  "<erase.down>",
+  "<cursor.up count=1>",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
 exports[`text (isCI = false) > defaultValue sets the value but does not render 1`] = `
 [
   "<cursor.hide>",
@@ -290,6 +318,34 @@ exports[`text (isCI = true) > can cancel 1`] = `
   "<erase.down>",
   "[31m■[39m  foo
 [90m│[39m",
+  "
+",
+  "<cursor.show>",
+]
+`;
+
+exports[`text (isCI = true) > clear prompt after done 1`] = `
+[
+  "<cursor.hide>",
+  "[90m│[39m
+[36m◆[39m  foo
+[36m│[39m  [7m[8m_[28m[27m
+[36m└[39m
+",
+  "<cursor.backward count=999><cursor.up count=4>",
+  "<cursor.down count=2>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  x█",
+  "<cursor.down count=2>",
+  "<cursor.backward count=999><cursor.up count=4>",
+  "<cursor.down count=2>",
+  "<erase.line><cursor.left count=1>",
+  "[36m│[39m  xy█",
+  "<cursor.down count=2>",
+  "<cursor.backward count=999><cursor.up count=4>",
+  "",
+  "<erase.down>",
+  "<cursor.up count=1>",
   "
 ",
   "<cursor.show>",

--- a/packages/prompts/test/autocomplete.test.ts
+++ b/packages/prompts/test/autocomplete.test.ts
@@ -168,6 +168,23 @@ describe('autocomplete', () => {
 		expect(isCancel(value)).toBe(true);
 		expect(output.buffer).toMatchSnapshot();
 	});
+
+	test('clear prompt after done', async () => {
+		const result = autocomplete({
+			message: 'foo',
+			options: testOptions,
+			input,
+			output,
+			clearPromptOnDone: true,
+		});
+
+		input.emit('keypress', '', { name: 'down' });
+		input.emit('keypress', '', { name: 'return' });
+
+		const value = await result;
+		expect(value).toBe('banana');
+		expect(output.buffer).toMatchSnapshot();
+	});
 });
 
 describe('autocompleteMultiselect', () => {
@@ -228,6 +245,26 @@ describe('autocompleteMultiselect', () => {
 			options: testOptions,
 			input,
 			output,
+		});
+
+		input.emit('keypress', '', { name: 'down' });
+		input.emit('keypress', '', { name: 'space' });
+		input.emit('keypress', '', { name: 'down' });
+		input.emit('keypress', '', { name: 'space' });
+		input.emit('keypress', '', { name: 'return' });
+
+		const value = await result;
+		expect(value).toEqual(['banana', 'cherry']);
+		expect(output.buffer).toMatchSnapshot();
+	});
+
+	test('clear prompt after done', async () => {
+		const result = autocompleteMultiselect({
+			message: 'Select fruits',
+			options: testOptions,
+			input,
+			output,
+			clearPromptOnDone: true,
 		});
 
 		input.emit('keypress', '', { name: 'down' });

--- a/packages/prompts/test/autocomplete.test.ts
+++ b/packages/prompts/test/autocomplete.test.ts
@@ -225,7 +225,7 @@ describe('autocomplete', () => {
 		await result;
 		expect(output.buffer).toMatchSnapshot();
 	});
-	
+
 	test('clear prompt after done', async () => {
 		const result = autocomplete({
 			message: 'foo',

--- a/packages/prompts/test/confirm.test.ts
+++ b/packages/prompts/test/confirm.test.ts
@@ -150,4 +150,20 @@ describe.each(['true', 'false'])('confirm (isCI = %s)', (isCI) => {
 		expect(prompts.isCancel(value)).toBe(true);
 		expect(output.buffer).toMatchSnapshot();
 	});
+
+	test('clear prompt after done', async () => {
+		const result = prompts.confirm({
+			message: 'foo',
+			input,
+			output,
+			clearPromptOnDone: true,
+		});
+
+		input.emit('keypress', '', { name: 'return' });
+
+		const value = await result;
+
+		expect(value).toBe(true);
+		expect(output.buffer).toMatchSnapshot();
+	});
 });

--- a/packages/prompts/test/group-multi-select.test.ts
+++ b/packages/prompts/test/group-multi-select.test.ts
@@ -367,4 +367,27 @@ describe.each(['true', 'false'])('groupMultiselect (isCI = %s)', (isCI) => {
 		expect(prompts.isCancel(value)).toBe(true);
 		expect(output.buffer).toMatchSnapshot();
 	});
+
+	test('clear prompt after done', async () => {
+		const result = prompts.groupMultiselect({
+			message: 'foo',
+			input,
+			output,
+			options: {
+				group1: [{ value: 'group1value0' }, { value: 'group1value1' }],
+				group2: [{ value: 'group2value0' }],
+			},
+			clearPromptOnDone: true,
+		});
+
+		input.emit('keypress', '', { name: 'down' });
+		input.emit('keypress', '', { name: 'space' });
+
+		input.emit('keypress', '', { name: 'return' });
+
+		const value = await result;
+
+		expect(value).toEqual(['group1value0']);
+		expect(output.buffer).toMatchSnapshot();
+	});
 });

--- a/packages/prompts/test/multi-select.test.ts
+++ b/packages/prompts/test/multi-select.test.ts
@@ -315,4 +315,22 @@ describe.each(['true', 'false'])('multiselect (isCI = %s)', (isCI) => {
 		expect(prompts.isCancel(value)).toBe(true);
 		expect(output.buffer).toMatchSnapshot();
 	});
+
+	test('clear prompt after done', async () => {
+		const result = prompts.multiselect({
+			message: 'foo',
+			options: [{ value: 'opt0' }, { value: 'opt1' }],
+			input,
+			output,
+			clearPromptOnDone: true,
+		});
+
+		input.emit('keypress', '', { name: 'space' });
+		input.emit('keypress', '', { name: 'return' });
+
+		const value = await result;
+
+		expect(value).toEqual(['opt0']);
+		expect(output.buffer).toMatchSnapshot();
+	});
 });

--- a/packages/prompts/test/password.test.ts
+++ b/packages/prompts/test/password.test.ts
@@ -149,4 +149,22 @@ describe.each(['true', 'false'])('password (isCI = %s)', (isCI) => {
 		expect(value).toBe('yz');
 		expect(output.buffer).toMatchSnapshot();
 	});
+
+	test('clear prompt after done', async () => {
+		const result = prompts.password({
+			message: 'foo',
+			input,
+			output,
+			clearPromptOnDone: true,
+		});
+
+		input.emit('keypress', 'x', { name: 'x' });
+		input.emit('keypress', 'y', { name: 'y' });
+		input.emit('keypress', '', { name: 'return' });
+
+		const value = await result;
+
+		expect(value).toBe('xy');
+		expect(output.buffer).toMatchSnapshot();
+	});
 });

--- a/packages/prompts/test/path.test.ts
+++ b/packages/prompts/test/path.test.ts
@@ -191,4 +191,21 @@ describe.each(['true', 'false'])('text (isCI = %s)', (isCI) => {
 		expect(value).toBe('/tmp/bar');
 		expect(output.buffer).toMatchSnapshot();
 	});
+
+	test('clear prompt after done', async () => {
+		const result = prompts.path({
+			message: 'foo',
+			input,
+			output,
+			root: '/tmp/',
+			clearPromptOnDone: true,
+		});
+
+		input.emit('keypress', '', { name: 'return' });
+
+		const value = await result;
+
+		expect(output.buffer).toMatchSnapshot();
+		expect(value).toBe('/tmp/bar');
+	});
 });

--- a/packages/prompts/test/select.test.ts
+++ b/packages/prompts/test/select.test.ts
@@ -145,4 +145,21 @@ describe.each(['true', 'false'])('select (isCI = %s)', (isCI) => {
 		expect(prompts.isCancel(value)).toBe(true);
 		expect(output.buffer).toMatchSnapshot();
 	});
+
+	test('clear prompt after done', async () => {
+		const result = prompts.select({
+			message: 'foo',
+			options: [{ value: 'opt0' }, { value: 'opt1' }],
+			input,
+			output,
+			clearPromptOnDone: true,
+		});
+
+		input.emit('keypress', '', { name: 'return' });
+
+		const value = await result;
+
+		expect(value).toBe('opt0');
+		expect(output.buffer).toMatchSnapshot();
+	});
 });

--- a/packages/prompts/test/text.test.ts
+++ b/packages/prompts/test/text.test.ts
@@ -205,4 +205,22 @@ describe.each(['true', 'false'])('text (isCI = %s)', (isCI) => {
 		expect(prompts.isCancel(value)).toBe(true);
 		expect(output.buffer).toMatchSnapshot();
 	});
+
+	test('clear prompt after done', async () => {
+		const result = prompts.text({
+			message: 'foo',
+			input,
+			output,
+			clearPromptOnDone: true,
+		});
+
+		input.emit('keypress', 'x', { name: 'x' });
+		input.emit('keypress', 'y', { name: 'y' });
+		input.emit('keypress', '', { name: 'return' });
+
+		const value = await result;
+
+		expect(value).toBe('xy');
+		expect(output.buffer).toMatchSnapshot();
+	});
 });


### PR DESCRIPTION
In this PR, i add `clearPromptOnDone` option for some prompts like on `inquirer`.
The prompt who get `clearPromptOnDone` option are:

- `autocomplete`
- `autocompleteMultiselect`
- `confirm`
- `groupMultiselect`
- `multiselect`
- `password`
- `path`
- `selectKey`
- `select`
- `text`

