### PR TITLE
fix: output submit gap only when guide enabled

### DIFF
--- a/.changeset/hungry-rice-film.md
+++ b/.changeset/hungry-rice-film.md
@@ -1,0 +1,5 @@
+---
+"@clack/prompts": patch
+---
+
+Fixes a withGuide rendering issue leaving extra spaces in text prompts.

--- a/packages/core/test/prompts/prompt.test.ts
+++ b/packages/core/test/prompts/prompt.test.ts
@@ -467,6 +467,7 @@ describe('Prompt', () => {
 		expect(eventSpy).not.toHaveBeenCalled();
 		expect(instance.state).to.equal('validating');
 
+		// biome-ignore lint/style/noNonNullAssertion: We know resolveValidation is defined
 		resolveValidation!(undefined);
 		await resultPromise;
 

--- a/packages/prompts/src/text.ts
+++ b/packages/prompts/src/text.ts
@@ -91,7 +91,7 @@ export const text = (opts: TextOptions) => {
 					return `${title.trim()}\n${errorPrefix}${userInput}\n${errorPrefixEnd}${errorText}\n`;
 				}
 				case 'submit': {
-					const valueText = value ? `  ${styleText('dim', value)}` : '';
+					const valueText = value ? `${hasGuide ? '  ' : ''}${styleText('dim', value)}` : '';
 					const submitPrefix = hasGuide ? styleText('gray', S_BAR) : '';
 					return `${title}${submitPrefix}${valueText}`;
 				}

--- a/packages/prompts/test/__snapshots__/text.test.ts.snap
+++ b/packages/prompts/test/__snapshots__/text.test.ts.snap
@@ -131,9 +131,14 @@ exports[`text (isCI = false) > global withGuide: false removes guide 1`] = `
 
 ",
   "<cursor.backward count=999><cursor.up count=3>",
+  "<cursor.down count=1>",
+  "<erase.line><cursor.left count=1>",
+  "x█",
+  "<cursor.down count=2>",
+  "<cursor.backward count=999><cursor.up count=3>",
   "<erase.down>",
   "[32m◇[39m  foo
-",
+[2mx[22m",
   "
 ",
   "<cursor.show>",
@@ -340,9 +345,14 @@ exports[`text (isCI = false) > withGuide: false removes guide 1`] = `
 
 ",
   "<cursor.backward count=999><cursor.up count=3>",
+  "<cursor.down count=1>",
+  "<erase.line><cursor.left count=1>",
+  "x█",
+  "<cursor.down count=2>",
+  "<cursor.backward count=999><cursor.up count=3>",
   "<erase.down>",
   "[32m◇[39m  foo
-",
+[2mx[22m",
   "
 ",
   "<cursor.show>",
@@ -480,9 +490,14 @@ exports[`text (isCI = true) > global withGuide: false removes guide 1`] = `
 
 ",
   "<cursor.backward count=999><cursor.up count=3>",
+  "<cursor.down count=1>",
+  "<erase.line><cursor.left count=1>",
+  "x█",
+  "<cursor.down count=2>",
+  "<cursor.backward count=999><cursor.up count=3>",
   "<erase.down>",
   "[32m◇[39m  foo
-",
+[2mx[22m",
   "
 ",
   "<cursor.show>",
@@ -689,9 +704,14 @@ exports[`text (isCI = true) > withGuide: false removes guide 1`] = `
 
 ",
   "<cursor.backward count=999><cursor.up count=3>",
+  "<cursor.down count=1>",
+  "<erase.line><cursor.left count=1>",
+  "x█",
+  "<cursor.down count=2>",
+  "<cursor.backward count=999><cursor.up count=3>",
   "<erase.down>",
   "[32m◇[39m  foo
-",
+[2mx[22m",
   "
 ",
   "<cursor.show>",

--- a/packages/prompts/test/text.test.ts
+++ b/packages/prompts/test/text.test.ts
@@ -216,6 +216,7 @@ describe.each(['true', 'false'])('text (isCI = %s)', (isCI) => {
 			output,
 		});
 
+		input.emit('keypress', 'x', { name: 'x' });
 		input.emit('keypress', '', { name: 'return' });
 
 		await result;
@@ -232,6 +233,7 @@ describe.each(['true', 'false'])('text (isCI = %s)', (isCI) => {
 			output,
 		});
 
+		input.emit('keypress', 'x', { name: 'x' });
 		input.emit('keypress', '', { name: 'return' });
 
 		await result;


### PR DESCRIPTION
In the text prompt, we output a `"  "` prefix to align the submitted
value with the guide. When the guide is disabled, this was leaving is
with an unnecessary gap.

This fix removes that gap.

Fixes #598.

## Type of change

<!-- Check one. -->

- [x] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [ ] Chore (dependencies, CI, tooling)

## Checklist

- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a changeset

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [ ] This PR includes AI-generated code
