### PR TITLE
chore: update biome and config file

### DIFF
--- a/.changeset/afraid-animals-call.md
+++ b/.changeset/afraid-animals-call.md
@@ -1,6 +1,0 @@
----
-"@clack/core": patch
-"@clack/prompts": patch
----
-
-Update `@biomejs/biome` toolchain to latest version and adapt configuration.

--- a/.changeset/afraid-animals-call.md
+++ b/.changeset/afraid-animals-call.md
@@ -1,0 +1,6 @@
+---
+"@clack/core": patch
+"@clack/prompts": patch
+---
+
+Update `@biomejs/biome` toolchain to latest version and adapt configuration.

--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,7 @@ root = true
 
 [*]
 indent_style = tab
+indent_size = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
@@ -9,4 +10,3 @@ insert_final_newline = true
 
 [*.{yml,json,yaml}]
 indent_style = space
-indent_size = 2

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "EditorConfig.EditorConfig",
+    "biomejs.biome"
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Thank you for your interest in contributing to Clack! This document provides det
 ### Prerequisites
 
 - [Node.js](https://nodejs.org/) (version specified in `.nvmrc`, currently v20.18.1)
-- [pnpm](https://pnpm.io/) (version 9.14.2 or higher)
+- [pnpm](https://pnpm.io/) (version 10.33.0 or higher)
 
 If you use [volta](https://volta.sh/) or [nvm](https://github.com/nvm-sh/nvm), the correct Node.js version will be automatically selected based on the project's `.nvmrc` file.
 
@@ -63,16 +63,16 @@ If you want to test changes to Clack packages in your own project, you can use p
    ```bash
    # In your project
    cd /path/to/your-project
-   
+
    # Link @clack/core
    pnpm link --global /path/to/clack/packages/core
-   
+
    # Link @clack/prompts
    pnpm link --global /path/to/clack/packages/prompts
    ```
 
    **Method 2: Using local path in package.json**
-   
+
    In your project's package.json, reference the local paths:
    ```json
    {
@@ -97,7 +97,7 @@ If you want to test changes to Clack packages in your own project, you can use p
    # In the clack repository
    cd /path/to/clack
    pnpm build
-   
+
    # In your project (if using Method 2)
    cd /path/to/your-project
    pnpm install
@@ -125,11 +125,11 @@ clack/
 
 ### Key Packages
 
-1. **@clack/core** (`packages/core/`): 
+1. **@clack/core** (`packages/core/`):
    - Contains the unstyled, extensible primitives for building CLI applications
    - The foundation layer that provides the core functionality
 
-2. **@clack/prompts** (`packages/prompts/`): 
+2. **@clack/prompts** (`packages/prompts/`):
    - Built on top of @clack/core
    - Provides beautiful, ready-to-use CLI prompt components
    - What most users will interact with directly
@@ -142,7 +142,7 @@ The `examples/` directory contains sample projects that demonstrate how to use C
 
 ### Common Commands
 
-- **Build all packages**: 
+- **Build all packages**:
   ```bash
   pnpm build
   ```
@@ -194,14 +194,14 @@ The `examples/` directory contains sample projects that demonstrate how to use C
    ```bash
    # Ensure everything builds
    pnpm build
-   
+
    # Check formatting and lint issues
    pnpm format
    pnpm lint
-   
+
    # Verify type correctness
    pnpm types
-   
+
    # Run tests
    pnpm test
    ```
@@ -269,7 +269,7 @@ When encountering issues during development:
 
 ### PR Previews
 
-Clack uses [pkg.pr.new](https://pkg.pr.new) (provided by [bolt.new](https://bolt.new)) to create continuous preview releases of all PRs. This simplifies testing and makes verifying bug fixes easier for our dependents. 
+Clack uses [pkg.pr.new](https://pkg.pr.new) (provided by [bolt.new](https://bolt.new)) to create continuous preview releases of all PRs. This simplifies testing and makes verifying bug fixes easier for our dependents.
 
 The workflow that builds a preview version and adds instructions for installation as a comment on your PR should run automatically if you have contributed to Clack before. First-time contributors may need to wait until a maintainer manually approves GitHub Actions running on your PR.
 
@@ -295,10 +295,10 @@ Clack maintains a stable `v0` branch alongside the main development branch. For 
    # Ensure you have the latest v0 branch
    git checkout v0
    git pull upstream v0
-   
+
    # Cherry-pick the squashed commit from main
    git cherry-pick <commit-hash>
-   
+
    # Push the changes
    git push upstream v0
    ```

--- a/biome.json
+++ b/biome.json
@@ -9,7 +9,6 @@
     "includes": [
       "**",
       "!pnpm-lock.yaml",
-      "!**/build",
       "!**/dist",
       "!**/node_modules",
       "!**/.vscode"

--- a/biome.json
+++ b/biome.json
@@ -1,47 +1,43 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.1.2/schema.json",
-  "vcs": { "enabled": false, "clientKind": "git", "useIgnoreFile": false },
-  "files": { "ignoreUnknown": false, "includes": ["**", "!**/dist/**"] },
-  "formatter": {
+  "$schema": "https://biomejs.dev/schemas/2.5.12/schema.json",
+  "vcs": {
     "enabled": true,
-    "useEditorconfig": true,
-    "formatWithErrors": false,
-    "indentStyle": "tab",
-    "indentWidth": 2,
-    "lineEnding": "lf",
-    "lineWidth": 100,
-    "attributePosition": "auto",
-    "bracketSpacing": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
     "includes": [
       "**",
-      "!**/.github/workflows/**/*.yml",
-      "!**/.changeset/**/*.md",
-      "!**/pnpm-lock.yaml",
-      "!**/package.json"
+      "!pnpm-lock.yaml",
+      "!**/build",
+      "!**/dist",
+      "!**/node_modules",
+      "!**/.vscode"
     ]
   },
-  "assist": { "actions": { "source": { "organizeImports": "on" } } },
+  "formatter": {
+    "useEditorconfig": true,
+    "lineWidth": 100
+  },
   "linter": {
-    "enabled": true,
-    "rules": { "recommended": true, "suspicious": { "noExplicitAny": "off" } }
+    "rules": {
+      "preset": "recommended",
+      "suspicious": {
+        "noExplicitAny": "off"
+      }
+    }
   },
   "javascript": {
     "formatter": {
-      "jsxQuoteStyle": "double",
-      "quoteProperties": "asNeeded",
-      "trailingCommas": "es5",
-      "semicolons": "always",
-      "arrowParentheses": "always",
-      "bracketSameLine": false,
       "quoteStyle": "single",
-      "attributePosition": "auto",
-      "bracketSpacing": true
+      "trailingCommas": "es5"
     }
   },
-  "overrides": [
-    {
-      "includes": ["**/*.json", "**/*.toml", "**/*.yml"],
-      "formatter": { "indentStyle": "space" }
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
     }
-  ]
+  }
 }

--- a/biome.json
+++ b/biome.json
@@ -6,13 +6,7 @@
     "useIgnoreFile": true
   },
   "files": {
-    "includes": [
-      "**",
-      "!pnpm-lock.yaml",
-      "!**/dist",
-      "!**/node_modules",
-      "!**/.vscode"
-    ]
+    "includes": ["**", "!pnpm-lock.yaml", "!**/dist", "!**/node_modules", "!**/.vscode"]
   },
   "formatter": {
     "useEditorconfig": true,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "pretest": "pnpm run build"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.1.2",
+    "@biomejs/biome": "^2.5.12",
     "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.31.0",
     "@types/node": "^20.19.39",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.1.2
-        version: 2.1.2
+        specifier: ^2.5.12
+        version: 2.5.12
       '@changesets/changelog-github':
         specifier: ^0.7.0
         version: 0.7.0
@@ -128,59 +128,59 @@ packages:
     resolution: {integrity: sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==}
     engines: {node: '>=6.9.0'}
 
-  '@biomejs/biome@2.1.2':
-    resolution: {integrity: sha512-yq8ZZuKuBVDgAS76LWCfFKHSYIAgqkxVB3mGVVpOe2vSkUTs7xG46zXZeNPRNVjiJuw0SZ3+J2rXiYx0RUpfGg==}
+  '@biomejs/biome@2.5.12':
+    resolution: {integrity: sha512-Lw4VHZRebrReBBnlHa12JQjnIBm3JJAA55PDB9LbBVBF0q4RYphm6KfmIjqtPhf61MxZ5Q9KoK8R8x+7per5Aw==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.1.2':
-    resolution: {integrity: sha512-leFAks64PEIjc7MY/cLjE8u5OcfBKkcDB0szxsWUB4aDfemBep1WVKt0qrEyqZBOW8LPHzrFMyDl3FhuuA0E7g==}
+  '@biomejs/cli-darwin-arm64@2.5.12':
+    resolution: {integrity: sha512-lCRY1rwgNeWNgTr4DI/u6ZwXTRwRLHAvbaio1YLLGS+4r1nhvB2ssyPqIpfUSmRveNfv0fn/N58C7CAdK2XVrg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.1.2':
-    resolution: {integrity: sha512-Nmmv7wRX5Nj7lGmz0FjnWdflJg4zii8Ivruas6PBKzw5SJX/q+Zh2RfnO+bBnuKLXpj8kiI2x2X12otpH6a32A==}
+  '@biomejs/cli-darwin-x64@2.5.12':
+    resolution: {integrity: sha512-vhPgwnh+6tN3ArdAXuET99xaNbFt7CG82Bqn+omHVLC5xdVx45JsYjGPmUIGNzjDek5XdNCP1HKksK7fn8+3bQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.1.2':
-    resolution: {integrity: sha512-qgHvafhjH7Oca114FdOScmIKf1DlXT1LqbOrrbR30kQDLFPEOpBG0uzx6MhmsrmhGiCFCr2obDamu+czk+X0HQ==}
+  '@biomejs/cli-linux-arm64-musl@2.5.12':
+    resolution: {integrity: sha512-couHYjFLL5uuI8ne6zhT7KwEsXo5YP7ry/2xmEqah7qanu0YmfDi3mwJg47YXSuv/NpZj22CZzcRH/5c4gjPSQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.1.2':
-    resolution: {integrity: sha512-NWNy2Diocav61HZiv2enTQykbPP/KrA/baS7JsLSojC7Xxh2nl9IczuvE5UID7+ksRy2e7yH7klm/WkA72G1dw==}
+  '@biomejs/cli-linux-arm64@2.5.12':
+    resolution: {integrity: sha512-2gp8aVwXYKdAtmBfRFCUuyDMcfN1ahHqUkGfLYrZlNRFmryMATLVvJgWKvyA8wu4Rwn5OSxM1UcUmOuOFNGeBQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.1.2':
-    resolution: {integrity: sha512-xlB3mU14ZUa3wzLtXfmk2IMOGL+S0aHFhSix/nssWS/2XlD27q+S6f0dlQ8WOCbYoXcuz8BCM7rCn2lxdTrlQA==}
+  '@biomejs/cli-linux-x64-musl@2.5.12':
+    resolution: {integrity: sha512-8A0oDW58/w9f/PQNYuq0sGUZtGtGrkNF4Z6n0PUoXpLCshi85vtKTv1XSznQawhdE4MXJ8ufpzHXyLFe87M/+w==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.1.2':
-    resolution: {integrity: sha512-Km/UYeVowygTjpX6sGBzlizjakLoMQkxWbruVZSNE6osuSI63i4uCeIL+6q2AJlD3dxoiBJX70dn1enjQnQqwA==}
+  '@biomejs/cli-linux-x64@2.5.12':
+    resolution: {integrity: sha512-SnvOs3TSTiuia4SQOUNe1aWC9RT4+YkjcKnOhL/nsKOV0k5ycgBkDzF0lUxKn1V7Q8CLTRq6iV23ZAivHomRoA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.1.2':
-    resolution: {integrity: sha512-G8KWZli5ASOXA3yUQgx+M4pZRv3ND16h77UsdunUL17uYpcL/UC7RkWTdkfvMQvogVsAuz5JUcBDjgZHXxlKoA==}
+  '@biomejs/cli-win32-arm64@2.5.12':
+    resolution: {integrity: sha512-b9vtoZFsuZt1pdjNwJvXl0f+BpayRzV008uS2+JpmwIKdSE2qdu4A/l04FESwLoou5g2E/Qlec0xwJydZplH+A==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.1.2':
-    resolution: {integrity: sha512-9zajnk59PMpjBkty3bK2IrjUsUHvqe9HWwyAWQBjGLE7MIBjbX2vwv1XPEhmO2RRuGoTkVx3WCanHrjAytICLA==}
+  '@biomejs/cli-win32-x64@2.5.12':
+    resolution: {integrity: sha512-B1R/l+CwEpKFSuqiwePzPNRk1EiJN8kc0UhdafNz6MZN9v5OFP9HYP1irptvWzHrwVI4blVNGMbxc5zt70m3IA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -1921,39 +1921,39 @@ snapshots:
 
   '@babel/runtime@7.28.2': {}
 
-  '@biomejs/biome@2.1.2':
+  '@biomejs/biome@2.5.12':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.1.2
-      '@biomejs/cli-darwin-x64': 2.1.2
-      '@biomejs/cli-linux-arm64': 2.1.2
-      '@biomejs/cli-linux-arm64-musl': 2.1.2
-      '@biomejs/cli-linux-x64': 2.1.2
-      '@biomejs/cli-linux-x64-musl': 2.1.2
-      '@biomejs/cli-win32-arm64': 2.1.2
-      '@biomejs/cli-win32-x64': 2.1.2
+      '@biomejs/cli-darwin-arm64': 2.5.12
+      '@biomejs/cli-darwin-x64': 2.5.12
+      '@biomejs/cli-linux-arm64': 2.5.12
+      '@biomejs/cli-linux-arm64-musl': 2.5.12
+      '@biomejs/cli-linux-x64': 2.5.12
+      '@biomejs/cli-linux-x64-musl': 2.5.12
+      '@biomejs/cli-win32-arm64': 2.5.12
+      '@biomejs/cli-win32-x64': 2.5.12
 
-  '@biomejs/cli-darwin-arm64@2.1.2':
+  '@biomejs/cli-darwin-arm64@2.5.12':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.1.2':
+  '@biomejs/cli-darwin-x64@2.5.12':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.1.2':
+  '@biomejs/cli-linux-arm64-musl@2.5.12':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.1.2':
+  '@biomejs/cli-linux-arm64@2.5.12':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.1.2':
+  '@biomejs/cli-linux-x64-musl@2.5.12':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.1.2':
+  '@biomejs/cli-linux-x64@2.5.12':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.1.2':
+  '@biomejs/cli-win32-arm64@2.5.12':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.1.2':
+  '@biomejs/cli-win32-x64@2.5.12':
     optional: true
 
   '@changesets/apply-release-plan@7.1.1':


### PR DESCRIPTION
## What does this PR do?

<!--
  Describe the change and why it's needed. Link to a related issue or discussion.
  If there is no issue, please explain why one isn't needed.
-->

Update `@biomejs/biome` to its latest version and adapt the config file to the current configuration specified in the project. I have omitted configuration options that are already set by default and, consequently, options that are not necessary. Full explanation:

#### Modified files:

- `.editorconfig`: Since all the project files will use a tab width of 2 for now, there's no need to set the configuration in Biome; just use the editorconfig option directly.

- `.vscode`: I've added an `extensions.json` file to improve integration with VS Code extensions and their forks, such as Cursor.

- `CONTRIBUTING.md`: I've changed the required version of pnpm to match the `packageManager` field in the `package.json` file in the project root.

#### Omited configurations:

| option | default value |
|--------|----------------|
| [`formatter.enabled`](https://biomejs.dev/reference/configuration/#formatterenabled) | `true` |
| [`formatter.formatWithErrors`](https://biomejs.dev/reference/configuration/#formatterformatwitherrors) | `false` |
| [`formatter.indentStyle`](https://biomejs.dev/reference/configuration/#formatterindentstyle) | `tab` (.editorconfig) |
| [`formatter.indentWidth`](https://biomejs.dev/reference/configuration/#formatterindentwidth) | `2` (.editorconfig) |
| [`formatter.lineEnding`](https://biomejs.dev/reference/configuration/#formatterlineending) | `lf` (.editorconfig) | 
| [`formatter.attributePosition`](https://biomejs.dev/reference/configuration/#formatterattributeposition) | `auto` |
| [`formatter.bracketSpacing`](https://biomejs.dev/reference/configuration/#formatterbracketspacing) | `true` |
| [`linter.enabled`](https://biomejs.dev/reference/configuration/#linterenabled) | `true` |
| [`javascript.formatter.jsxQuoteStyle`](https://biomejs.dev/reference/configuration/#javascriptformatterjsxquotestyle) | `double` |
| [`javascript.formatter.quoteProperties`](https://biomejs.dev/reference/configuration/#javascriptformatterquoteproperties) | `asNeeded` |
| [`javascript.formatter.semicolons`](https://biomejs.dev/reference/configuration/#javascriptformattersemicolons) | `always` |
| [`javascript.formatter.arrowParentheses`](https://biomejs.dev/reference/configuration/#javascriptformatterarrowparentheses) | `always` |
| [`javascript.formatter.bracketSameLine`](https://biomejs.dev/reference/configuration/#javascriptformatterbracketsameline) | `false` |
| [`javascript.formatter.bracketSpacing`](https://biomejs.dev/reference/configuration/#javascriptformatterbracketspacing) | `true` |
| [`javascript.formatter.attributePosition`](https://biomejs.dev/reference/configuration/#javascriptformatterattributeposition) | `auto` |

- [`overrides`](https://biomejs.dev/reference/configuration/#overrides): Since there are no `.toml` files and Biome does not yet support `.yml` files, it is not necessary to include these files in the configuration. Biome will never modify them.

#### Observations:

On GitHub, files indented with tabs appear to have a 4-space indent, while in the editor they show up as 2 spaces, as specified in the settings. Maybe I should just use spaces for everything?


## Type of change

<!-- Check one. -->

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Performance improvement
- [ ] Tests
- [x] Chore (dependencies, CI, tooling)

## Checklist

- [x] `pnpm test` passes (or targeted tests for my change)
- [x] `pnpm format` has been run
- [x] I have added/updated tests for my changes (if applicable)
- [x] I have added a changeset

## AI-generated code disclosure

<!-- If any part of this PR was generated by AI tools (Copilot, Claude, GPT, Cursor, etc.), check the box. This is fine — we just need to know so reviewers can pay extra attention to edge cases. -->

- [ ] This PR includes AI-generated code
